### PR TITLE
Enable AI tracing: spans (with tool inputs) persist to mastra_ai_spans

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mastra/core": "^1.24.1",
         "@mastra/loggers": "^1.1.1",
         "@mastra/memory": "^1.15.0",
+        "@mastra/observability": "^1.14.1",
         "@mastra/pg": "^1.9.2",
         "@notionhq/client": "^5.9.0",
         "@sentry/node": "^10.36.0",
@@ -3074,6 +3075,19 @@
       },
       "peerDependencies": {
         "@mastra/core": ">=1.4.1-0 <2.0.0-0",
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@mastra/observability": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@mastra/observability/-/observability-1.14.1.tgz",
+      "integrity": "sha512-VKfn3mE1mNFOXgY9Pr9sy5L4q4xLnoLj501gFMOr0teNnRMvAiANVB+p4rnooDfM4i8nzLDG9icM80uMsgXTzQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "@mastra/core": ">=1.16.0-0 <2.0.0-0",
         "zod": "^3.25.0 || ^4.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@mastra/core": "^1.24.1",
     "@mastra/loggers": "^1.1.1",
     "@mastra/memory": "^1.15.0",
+    "@mastra/observability": "^1.14.1",
     "@mastra/pg": "^1.9.2",
     "@notionhq/client": "^5.9.0",
     "@sentry/node": "^10.36.0",

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -1,6 +1,7 @@
 import { Mastra } from '@mastra/core/mastra';
 import { MASTRA_RESOURCE_ID_KEY } from '@mastra/core/request-context';
 import { Observability, MastraStorageExporter, SensitiveDataFilter } from '@mastra/observability';
+import { bulkyPayloadTruncator } from './utils/tracing.js';
 import { weatherAgent, ashAgent, pierreAgent, projectManagerAgent, zoeAgent, zoeAgentHaiku, expoAgent, assistantAgent, assistantAgentHaiku, platformAgent, one2bAgent, actionItemsAgent, meetingContextAgent, documentTrackerAgent } from './agents';
 import { memory, storage } from './memory/index.js';
 import { createLogger } from './utils/logger.js';
@@ -67,16 +68,24 @@ export const mastra = new Mastra({
   // AI tracing: spans for every agent step + tool call (with inputs) land
   // in mastra.mastra_ai_spans. This is the signal that was missing during
   // the 2026-06-12 web_fetch incident — the table existed but stayed empty.
-  // SensitiveDataFilter redacts apiKey/token/secret-like fields in spans.
-  observability: new Observability({
-    configs: {
-      default: {
-        serviceName: 'mastra',
-        exporters: [new MastraStorageExporter()],
-        spanOutputProcessors: [new SensitiveDataFilter()],
-      },
-    },
-  }),
+  // SensitiveDataFilter redacts apiKey/token/secret-like fields;
+  // bulkyPayloadTruncator caps prompt-sized step/generation payloads while
+  // keeping tool-call inputs intact. Disabled in dev by default: local
+  // `mastra dev` shares the production DATABASE_URL, and dev spans would
+  // pollute the prod agent-quality signal. Opt in with MASTRA_TRACING=true.
+  ...(!isDev || process.env.MASTRA_TRACING === 'true'
+    ? {
+        observability: new Observability({
+          configs: {
+            default: {
+              serviceName: isDev ? 'mastra-dev' : 'mastra',
+              exporters: [new MastraStorageExporter()],
+              spanOutputProcessors: [new SensitiveDataFilter(), bulkyPayloadTruncator],
+            },
+          },
+        }),
+      }
+    : {}),
   logger: logger.raw,
   server: {
     port: parseInt(process.env.PORT || '4111', 10),

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -1,7 +1,8 @@
 import { Mastra } from '@mastra/core/mastra';
 import { MASTRA_RESOURCE_ID_KEY } from '@mastra/core/request-context';
+import { Observability, MastraStorageExporter, SensitiveDataFilter } from '@mastra/observability';
 import { weatherAgent, ashAgent, pierreAgent, projectManagerAgent, zoeAgent, zoeAgentHaiku, expoAgent, assistantAgent, assistantAgentHaiku, platformAgent, one2bAgent, actionItemsAgent, meetingContextAgent, documentTrackerAgent } from './agents';
-import { memory } from './memory/index.js';
+import { memory, storage } from './memory/index.js';
 import { createLogger } from './utils/logger.js';
 import { createTelegramBot, cleanupTelegramBot } from './bots/ostrom-telegram.js';
 import { createTelegramGateway, cleanupTelegramGateway } from './bots/telegram-gateway.js';
@@ -60,6 +61,22 @@ logger.info('🧠 [MAIN] Brain prompt versions computed', brainVersions);
 export const mastra = new Mastra({
   agents,
   memory: { default: memory },
+  // Top-level storage is required by the observability exporter below;
+  // shares the Memory PostgresStore (schema 'mastra').
+  storage,
+  // AI tracing: spans for every agent step + tool call (with inputs) land
+  // in mastra.mastra_ai_spans. This is the signal that was missing during
+  // the 2026-06-12 web_fetch incident — the table existed but stayed empty.
+  // SensitiveDataFilter redacts apiKey/token/secret-like fields in spans.
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [new MastraStorageExporter()],
+        spanOutputProcessors: [new SensitiveDataFilter()],
+      },
+    },
+  }),
   logger: logger.raw,
   server: {
     port: parseInt(process.env.PORT || '4111', 10),

--- a/src/mastra/memory/index.ts
+++ b/src/mastra/memory/index.ts
@@ -1,12 +1,17 @@
 import { Memory } from '@mastra/memory';
 import { PostgresStore } from '@mastra/pg';
 
+// Shared store: Memory persistence AND the Mastra instance's top-level
+// storage (required by the observability MastraStorageExporter so AI
+// tracing spans land in mastra.mastra_ai_spans).
+export const storage = new PostgresStore({
+  id: 'memory',
+  connectionString: process.env.DATABASE_URL!,
+  schemaName: 'mastra',
+});
+
 export const memory = new Memory({
-  storage: new PostgresStore({
-    id: 'memory',
-    connectionString: process.env.DATABASE_URL!,
-    schemaName: 'mastra',
-  }),
+  storage,
   options: {
     observationalMemory: {
       scope: 'resource',

--- a/src/mastra/utils/tracing.ts
+++ b/src/mastra/utils/tracing.ts
@@ -1,0 +1,33 @@
+import type { AnySpan, SpanOutputProcessor } from '@mastra/core/observability';
+
+// Generation/step/run spans embed the full message history (Zoe's prompt is
+// ~65K chars, up to 12 steps per turn) — persisting that verbatim into the
+// shared memory Postgres is a slow-motion disk-fill. Cap those payloads but
+// leave tool-call spans untouched: tool inputs are the incident-diagnosis
+// signal this tracing exists to capture (2026-06-12 web_fetch incident).
+const SPAN_PAYLOAD_CHAR_CAP = 2_000;
+const BULKY_SPAN_TYPES = new Set(['agent_run', 'model_generation', 'model_step', 'model_chunk']);
+
+function truncatePayload(value: unknown): unknown {
+  if (value == null) return value;
+  let serialized: string;
+  try {
+    serialized = typeof value === 'string' ? value : JSON.stringify(value);
+  } catch {
+    return '[unserializable]';
+  }
+  if (serialized == null || serialized.length <= SPAN_PAYLOAD_CHAR_CAP) return value;
+  return `${serialized.slice(0, SPAN_PAYLOAD_CHAR_CAP)}…[truncated ${serialized.length} chars]`;
+}
+
+export const bulkyPayloadTruncator: SpanOutputProcessor = {
+  name: 'bulky-payload-truncator',
+  process(span?: AnySpan): AnySpan | undefined {
+    if (span && BULKY_SPAN_TYPES.has(span.type)) {
+      span.input = truncatePayload(span.input);
+      span.output = truncatePayload(span.output);
+    }
+    return span;
+  },
+  shutdown: async () => {},
+};


### PR DESCRIPTION
## Why

During the 2026-06-12 web_fetch `url_not_allowed` incident (two user-facing turn failures at 20:50 and 21:06), the `mastra.mastra_ai_spans` table existed but was empty — AI tracing was never enabled. We could prove *that* the agent called web_fetch (Railway error logs) but not *what URL* it tried or what steps preceded it.

## What

- Enable `Observability` with `MastraStorageExporter` so spans for agent runs, model steps, and tool calls — **including tool inputs** — persist to `mastra.mastra_ai_spans`.
- `SensitiveDataFilter` redacts apiKey/token/secret-like fields before writing.
- Share the Memory `PostgresStore` as the Mastra instance's top-level `storage` (required by the exporter; same schema, no new infra).
- Adds `@mastra/observability@1.14.1`.

## Verification

Booted locally and ran one minimal agent call: `agent_run`, `model_generation` (full input), `model_step`, and `model_chunk` spans landed in `mastra.mastra_ai_spans`.

Companion change in the exponential repo persists redacted tool-call args on `AiInteractionHistory.toolCalls` (always-on cheap layer; this PR is the deep signal).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled observability and tracing capabilities for improved monitoring and debugging.
  * Implemented automatic sensitive data filtering to redact confidential information in traces and logs.

* **Chores**
  * Added observability runtime dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->