### PR TITLE
Fix web_fetch/web_search error results crashing turns (exponential-foag)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/node-cron": "^3.0.11",
         "@types/pg": "^8.20.0",
         "@types/qrcode": "^1.5.6",
+        "patch-package": "^8.0.1",
         "tsx": "^4.19.3",
         "typescript": "^5.8.3",
         "vitest": "^4.1.8"
@@ -5713,6 +5714,13 @@
       "integrity": "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==",
       "license": "Apache-2.0"
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@zeit/schemas": {
       "version": "2.36.0",
       "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
@@ -6767,6 +6775,22 @@
         "remark-stringify": "^11.0.0",
         "remend": "^1.2.1",
         "unified": "^11.0.5"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cli-boxes": {
@@ -8137,6 +8161,16 @@
         "yaml": "^2.3.4"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
@@ -9477,6 +9511,26 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -9505,6 +9559,16 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -9581,6 +9645,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/lazystream": {
@@ -11391,6 +11465,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openapi-fetch": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.17.0.tgz",
@@ -11559,6 +11650,68 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/path-exists": {
@@ -13375,6 +13528,16 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
@@ -13817,6 +13980,16 @@
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "logs": "tail -f mastra.log",
     "build": "mastra build",
     "start": "node .mastra/output/index.mjs",
-    "eval-replay": "tsx --env-file=.env src/mastra/evals/eval-replay.ts"
+    "eval-replay": "tsx --env-file=.env src/mastra/evals/eval-replay.ts",
+    "postinstall": "patch-package"
   },
   "keywords": [],
   "author": "",
@@ -48,6 +49,7 @@
     "@types/node-cron": "^3.0.11",
     "@types/pg": "^8.20.0",
     "@types/qrcode": "^1.5.6",
+    "patch-package": "^8.0.1",
     "tsx": "^4.19.3",
     "typescript": "^5.8.3",
     "vitest": "^4.1.8"

--- a/patches/@ai-sdk+anthropic+3.0.37.patch
+++ b/patches/@ai-sdk+anthropic+3.0.37.patch
@@ -1,0 +1,84 @@
+diff --git a/node_modules/@ai-sdk/anthropic/dist/index.js b/node_modules/@ai-sdk/anthropic/dist/index.js
+index f008a25..1567fad 100644
+--- a/node_modules/@ai-sdk/anthropic/dist/index.js
++++ b/node_modules/@ai-sdk/anthropic/dist/index.js
+@@ -2191,6 +2191,18 @@ async function convertToAnthropicMessagesPrompt({
+                     });
+                     break;
+                   }
++                  if (output.value && typeof output.value === "object" && output.value.type === "web_fetch_tool_result_error") {
++                    anthropicContent.push({
++                      type: "web_fetch_tool_result",
++                      tool_use_id: part.toolCallId,
++                      content: {
++                        type: "web_fetch_tool_result_error",
++                        error_code: typeof output.value.errorCode === "string" ? output.value.errorCode : "unavailable"
++                      },
++                      cache_control: cacheControl
++                    });
++                    break;
++                  }
+                   const webFetchOutput = await (0, import_provider_utils11.validateTypes)({
+                     value: output.value,
+                     schema: webFetch_20250910OutputSchema
+@@ -2226,6 +2238,18 @@ async function convertToAnthropicMessagesPrompt({
+                     });
+                     break;
+                   }
++                  if (output.value && typeof output.value === "object" && !Array.isArray(output.value) && output.value.type === "web_search_tool_result_error") {
++                    anthropicContent.push({
++                      type: "web_search_tool_result",
++                      tool_use_id: part.toolCallId,
++                      content: {
++                        type: "web_search_tool_result_error",
++                        error_code: typeof output.value.errorCode === "string" ? output.value.errorCode : "unavailable"
++                      },
++                      cache_control: cacheControl
++                    });
++                    break;
++                  }
+                   const webSearchOutput = await (0, import_provider_utils11.validateTypes)({
+                     value: output.value,
+                     schema: webSearch_20250305OutputSchema
+diff --git a/node_modules/@ai-sdk/anthropic/dist/index.mjs b/node_modules/@ai-sdk/anthropic/dist/index.mjs
+index 8320b5f..7ca20fa 100644
+--- a/node_modules/@ai-sdk/anthropic/dist/index.mjs
++++ b/node_modules/@ai-sdk/anthropic/dist/index.mjs
+@@ -2215,6 +2215,18 @@ async function convertToAnthropicMessagesPrompt({
+                     });
+                     break;
+                   }
++                  if (output.value && typeof output.value === "object" && output.value.type === "web_fetch_tool_result_error") {
++                    anthropicContent.push({
++                      type: "web_fetch_tool_result",
++                      tool_use_id: part.toolCallId,
++                      content: {
++                        type: "web_fetch_tool_result_error",
++                        error_code: typeof output.value.errorCode === "string" ? output.value.errorCode : "unavailable"
++                      },
++                      cache_control: cacheControl
++                    });
++                    break;
++                  }
+                   const webFetchOutput = await validateTypes2({
+                     value: output.value,
+                     schema: webFetch_20250910OutputSchema
+@@ -2250,6 +2262,18 @@ async function convertToAnthropicMessagesPrompt({
+                     });
+                     break;
+                   }
++                  if (output.value && typeof output.value === "object" && !Array.isArray(output.value) && output.value.type === "web_search_tool_result_error") {
++                    anthropicContent.push({
++                      type: "web_search_tool_result",
++                      tool_use_id: part.toolCallId,
++                      content: {
++                        type: "web_search_tool_result_error",
++                        error_code: typeof output.value.errorCode === "string" ? output.value.errorCode : "unavailable"
++                      },
++                      cache_control: cacheControl
++                    });
++                    break;
++                  }
+                   const webSearchOutput = await validateTypes2({
+                     value: output.value,
+                     schema: webSearch_20250305OutputSchema

--- a/scripts/test-webfetch-error-patch.mjs
+++ b/scripts/test-webfetch-error-patch.mjs
@@ -1,0 +1,74 @@
+// Regression test for the @ai-sdk/anthropic web_fetch error-passthrough patch.
+// Replays the exact poisoned-message shape from prod (2026-06-12 incident):
+// a provider-executed webFetch tool-result whose output is typed `json` but
+// whose value is the error variant. Unpatched: AI_TypeValidationError before
+// the request is even sent (proven 3x in prod). Patched: the request goes out
+// with a proper web_fetch_tool_result_error block.
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+
+const captured = [];
+const fakeFetch = async (_url, init) => {
+  captured.push(JSON.parse(init.body));
+  return new Response(
+    JSON.stringify({
+      id: 'msg_test',
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5-20250929',
+      content: [{ type: 'text', text: 'Understood — that page could not be fetched.' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+};
+
+const anthropic = createAnthropic({ apiKey: 'test-key', fetch: fakeFetch });
+
+const result = await generateText({
+  model: anthropic('claude-sonnet-4-5-20250929'),
+  tools: { webFetch: anthropic.tools.webFetch_20250910({}) },
+  messages: [
+    { role: 'user', content: 'What is on the goal page?' },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'srvtoolu_test1',
+          toolName: 'webFetch',
+          input: { url: 'https://www.exponential.im/w/personal-cmdfuz6e/goals/19' },
+          providerExecuted: true,
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'srvtoolu_test1',
+          toolName: 'webFetch',
+          // The poisoned shape: error payload under a success-typed output.
+          output: {
+            type: 'json',
+            value: { type: 'web_fetch_tool_result_error', errorCode: 'url_not_allowed' },
+          },
+          providerExecuted: true,
+        },
+      ],
+    },
+    { role: 'user', content: 'ok, what now?' },
+  ],
+});
+
+const body = captured[0];
+const blocks = body.messages.flatMap((m) => (Array.isArray(m.content) ? m.content : []));
+const errBlock = blocks.find((b) => b.type === 'web_fetch_tool_result');
+
+if (!errBlock) throw new Error('FAIL: no web_fetch_tool_result block in outgoing request');
+if (errBlock.content?.type !== 'web_fetch_tool_result_error')
+  throw new Error('FAIL: block is not the error variant: ' + JSON.stringify(errBlock));
+if (errBlock.content?.error_code !== 'url_not_allowed')
+  throw new Error('FAIL: wrong error_code: ' + JSON.stringify(errBlock.content));
+if (!result.text) throw new Error('FAIL: no text result');
+
+console.log('PASS: poisoned web_fetch result converted to proper error block:');
+console.log('  ', JSON.stringify(errBlock.content));
+console.log('PASS: turn completed, model said:', JSON.stringify(result.text));


### PR DESCRIPTION
## Root cause (fully diagnosed via prod spans + memory DB)

1. **2026-06-12 ~12:22**: on a goal page, Zoe tried to `webFetch` the app's own URL (`…/goals/19`). Anthropic refused: `url_not_allowed`.
2. `@mastra/core` persisted the refusal with the error flag dropped — stored as a *successful* result (`state: "result"`, value = the error payload).
3. On every subsequent turn, `@ai-sdk/anthropic` validated that payload against the success-only `webFetch_20250910OutputSchema` while **building the request** → `AI_TypeValidationError` at step 0, before the model ran.
4. **Resource-scoped observational memory** carried the poisoned message into every new thread, and crashed turns write no messages — so the poison could never age out. One bad fetch = all conversations broken indefinitely.

## Fix

`patch-package` on `@ai-sdk/anthropic@3.0.37` (`dist/index.{js,mjs}`): when a `json`-typed web_fetch/web_search output value is actually the documented error variant, emit the proper `*_tool_result_error` content block instead of validating against the success schema. The model sees "fetch failed" and moves on. web_search gets the same guard (identical latent crash class — its error variant is an object, the schema expects an array).

`postinstall: patch-package` added so Railway applies it on every install.

## Verification

`node scripts/test-webfetch-error-patch.mjs` — replays the exact poisoned prod shape through `generateText` with a stub fetch:
- outgoing request contains `{"type":"web_fetch_tool_result_error","error_code":"url_not_allowed"}`
- the turn completes normally

## Related

- The one existing poisoned prod row was hot-fixed by hand (message `e3a417c4`, webFetch invocation replaced with a text note; backup retained).
- Upstream issues to file: vercel/ai (schema missing error variant) and mastra-ai/mastra (error flag dropped at persistence).
- Beads: `exponential-foag`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for AI tool integration failures, specifically for web fetch and search operations. Enhanced error reporting ensures proper error codes and status information are included in AI responses.

* **Chores**
  * Added development dependencies and automated tooling for managing dependency patches and validating against regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->