### PR TITLE
quick-create-action input alias + daily AI-span retention sweep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "mastra": "^1.5.0",
         "node-cron": "^4.2.1",
         "node-telegram-bot-api": "^0.66.0",
+        "pg": "^8.21.0",
         "qrcode": "^1.5.4",
         "tradescape-sdk": "0.1.0",
         "zod": "^3.25.0"
@@ -11635,14 +11636,14 @@
       "license": "MIT"
     },
     "node_modules/pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -11650,7 +11651,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
+        "pg-cloudflare": "^1.4.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -11662,16 +11663,16 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
@@ -11684,18 +11685,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "license": "MIT"
     },
     "node_modules/pg-types": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mastra": "^1.5.0",
     "node-cron": "^4.2.1",
     "node-telegram-bot-api": "^0.66.0",
+    "pg": "^8.21.0",
     "qrcode": "^1.5.4",
     "tradescape-sdk": "0.1.0",
     "zod": "^3.25.0"

--- a/src/mastra/agents/zoe-agent.ts
+++ b/src/mastra/agents/zoe-agent.ts
@@ -123,8 +123,8 @@ You're not a chatbot. You're not a productivity bot. You're something between a 
 You have real tools that create, read, and update data. When someone asks you to do something actionable, call the tool — don't describe what they *could* do or give them instructions on how to do it themselves.
 
 ### Action & Task Management
-- **quick-create-action**: Create actions from natural language. Parses dates ("tomorrow", "next Monday", "Friday") and matches project names from the text automatically. This is your default for creating tasks — just pass the user's request as-is.
-  Example input: "Review the Operating Agreement for Commons Lab Exec tomorrow"
+- **quick-create-action**: Create actions from natural language. Parses dates ("tomorrow", "next Monday", "Friday") and matches project names from the text automatically. This is your default for creating tasks — pass the user's request as-is in the \`text\` parameter.
+  Example call: { "text": "Review the Operating Agreement for Commons Lab Exec tomorrow" }
 - **create-project-action**: Create actions with explicit projectId, name, priority (Quick/Short/Long/Research), and optional description/dueDate. Use when you already have the project ID and want precise control over priority or description.
 - **update-action**: Update an existing action's fields — rename it, change priority/status, set due dates, or move it to a different project by setting a new projectId. Set projectId to null to unassign from any project.
 

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -14,6 +14,7 @@ import { initSentry, captureException, flushSentry } from './utils/sentry.js';
 import { assertAgentsValid } from './utils/validate-agents.js';
 import { computeBrainVersions, agentIdFromPath, BRAIN_VERSION_HEADER } from './utils/brain-version.js';
 import { startScheduler, stopScheduler, triggerCheck, deliverWhatsAppBriefings } from './proactive/index.js';
+import { startSpanRetention, stopSpanRetention } from './utils/span-retention.js';
 import jwt from 'jsonwebtoken';
 import { createHmac, timingSafeEqual } from 'crypto';
 
@@ -260,6 +261,12 @@ if (enableProactive) {
   logger.info('📵 [MAIN] Proactive scheduler disabled (set ENABLE_PROACTIVE_SCHEDULER=true to enable)');
 }
 
+// Daily prune of AI tracing spans (exponential-gnui). Railway-only: local
+// dev points at a shared DB it shouldn't be deleting from.
+if (isRailway) {
+  startSpanRetention(logger);
+}
+
 // Add graceful shutdown handling
 const shutdown = async (signal: string, error?: Error) => {
   logger.info(`🛑 [MAIN] Received ${signal}, starting graceful shutdown...`);
@@ -269,6 +276,8 @@ const shutdown = async (signal: string, error?: Error) => {
     if (error) {
       captureException(error, { operation: `shutdown:${signal}` });
     }
+
+    stopSpanRetention();
 
     // Cleanup bots and gateways
     if (enableTelegram) {

--- a/src/mastra/tools/index.ts
+++ b/src/mastra/tools/index.ts
@@ -644,13 +644,21 @@ export const createProjectActionTool = createTool({
 export const quickCreateActionTool = createTool({
   id: "quick-create-action",
   description:
-    "Create a new action using natural language. Automatically parses dates like 'tomorrow' or 'next Monday' and matches project names from the text. Use this when the user wants to create an action without specifying project ID or priority explicitly.",
+    "Create a new action using natural language. Pass the action description in the `text` parameter — e.g. { \"text\": \"Call John tomorrow\" }. Automatically parses dates like 'tomorrow' or 'next Monday' and matches project names from the text. Use this when the user wants to create an action without specifying project ID or priority explicitly.",
   inputSchema: z.object({
     text: z
       .string()
+      .optional()
       .describe(
         "Natural language action description. Can include dates ('tomorrow', 'next week', 'today') and project names ('for Marketing project', 'add to Exercise'). Examples: 'Call John tomorrow', 'Review docs for Marketing project', 'Buy groceries next Monday'"
       ),
+    // Models calling via deferred tool-search regularly guess `input`
+    // instead of `text` (observed 2026-06-12: 8 wasted validation
+    // round-trips on one turn). Accept it as an alias.
+    input: z
+      .string()
+      .optional()
+      .describe("Alias for `text` — prefer `text`."),
   }),
   outputSchema: z.object({
     success: z.boolean(),
@@ -688,9 +696,16 @@ export const quickCreateActionTool = createTool({
     const userId = requestContext?.get("userId");
     const projectId = requestContext?.get("projectId");
 
-    console.log(`🎯 [quickCreateAction] INPUT: text="${inputData.text}"`);
+    const text = inputData.text ?? inputData.input;
+    if (!text) {
+      throw new Error(
+        'Missing action description: pass it in the `text` parameter, e.g. { "text": "Call John tomorrow" }'
+      );
+    }
+
+    console.log(`🎯 [quickCreateAction] INPUT: text="${text}"`);
     console.log(`🎯 [quickCreateAction] CONTEXT: authToken=${authToken ? "present" : "MISSING"}, userId=${userId || "none"}, projectId=${projectId || "none"}`);
-    console.log(`🎯 [quickCreateAction] SENDING TO TRPC: { text: "${inputData.text}", projectId: ${projectId ? `"${projectId}"` : "undefined"} }`);
+    console.log(`🎯 [quickCreateAction] SENDING TO TRPC: { text: "${text}", projectId: ${projectId ? `"${projectId}"` : "undefined"} }`);
 
     if (!authToken) {
       throw new Error("No authentication token available");
@@ -699,7 +714,7 @@ export const quickCreateActionTool = createTool({
     try {
       const { data: result } = await authenticatedTrpcCall(
         "mastra.quickCreateAction",
-        { text: inputData.text, projectId: projectId || undefined },
+        { text, projectId: projectId || undefined },
         { authToken, sessionId, userId }
       );
 

--- a/src/mastra/utils/span-retention.ts
+++ b/src/mastra/utils/span-retention.ts
@@ -1,0 +1,55 @@
+import pg from 'pg';
+
+// AI tracing spans (mastra.mastra_ai_spans) accumulate forever otherwise —
+// the table shares the memory Postgres, so unbounded growth eventually
+// degrades live chat (exponential-gnui). Payloads are already capped by
+// bulkyPayloadTruncator; this prunes whole rows past the retention window.
+const RETENTION_DAYS = Number(process.env.SPAN_RETENTION_DAYS ?? '30');
+const SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+type Logger = { info: (msg: string) => void; error: (msg: string) => void };
+
+let timer: ReturnType<typeof setInterval> | undefined;
+
+async function sweep(logger: Logger): Promise<void> {
+  const pool = new pg.Pool({
+    connectionString: process.env.DATABASE_URL,
+    max: 1,
+  });
+  try {
+    const result = await pool.query(
+      `DELETE FROM mastra.mastra_ai_spans WHERE "startedAt" < now() - ($1 || ' days')::interval`,
+      [String(RETENTION_DAYS)],
+    );
+    logger.info(
+      `🧹 [span-retention] Pruned ${result.rowCount ?? 0} spans older than ${RETENTION_DAYS}d`,
+    );
+  } catch (err) {
+    logger.error(`🧹 [span-retention] Sweep failed: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    await pool.end().catch(() => undefined);
+  }
+}
+
+/**
+ * Start the daily retention sweep. First run is delayed a minute so boot
+ * isn't competing with the gateways and agent validation for the DB.
+ */
+export function startSpanRetention(logger: Logger): void {
+  if (timer) return;
+  if (RETENTION_DAYS <= 0) {
+    logger.info('🧹 [span-retention] Disabled (SPAN_RETENTION_DAYS <= 0)');
+    return;
+  }
+  setTimeout(() => {
+    void sweep(logger);
+  }, 60_000);
+  timer = setInterval(() => {
+    void sweep(logger);
+  }, SWEEP_INTERVAL_MS);
+}
+
+export function stopSpanRetention(): void {
+  if (timer) clearInterval(timer);
+  timer = undefined;
+}


### PR DESCRIPTION
Two fixes from tonight's Leadership-actions run (companion to exponential#187).

## 1. quick-create-action parameter mismatch (`exponential-cldg`, mastra half)

Prod spans showed the model calling the tool with `{"input": "…"}` instead of `{"text": "…"}` — 8 wasted validation round-trips on one turn (the schema is deferred behind tool-search, so the model guesses from the prose description).

- Schema accepts `input` as a documented alias for `text` (execute resolves `text ?? input`, throws a self-explanatory error if neither).
- Tool description now names the parameter with an example call.
- Zoe's instructions show the exact call shape instead of just prose.

## 2. Daily span retention (`exponential-gnui`)

`mastra.mastra_ai_spans` had no pruning. Daily sweep deletes rows older than `SPAN_RETENTION_DAYS` (default 30, ≤0 disables). Railway-only — local dev points at a shared DB it shouldn't delete from. Wired into boot and graceful shutdown; `pg` promoted to a direct dependency.

## Verification

`tsc --noEmit` clean; lockfile reconciled with `npm install --package-lock-only`. Independent of #17 (rebased onto main) — both can merge in either order.