### PR TITLE
fix(memory): set lastMessages: 40 to restore context parity

### DIFF
--- a/src/mastra/memory/index.ts
+++ b/src/mastra/memory/index.ts
@@ -13,6 +13,16 @@ export const storage = new PostgresStore({
 export const memory = new Memory({
   storage,
   options: {
+    // Conversational recall window. The exponential chat route
+    // (src/app/api/chat/stream/route.ts) now sends ONLY the latest user
+    // message and relies on thread memory to supply prior turns, replacing a
+    // client transcript that was trimmed to ~20k tokens. semanticRecall is NOT
+    // enabled here (no vector store/embedder), so `lastMessages` is the ONLY
+    // recall path — the Mastra default of 10 is too small to cover a multi-turn
+    // planning session and silently drops context the transcript used to carry.
+    // 40 restores parity with the prior working set. If this is lowered, the
+    // chat route's "prior turns come from thread memory" assumption breaks.
+    lastMessages: 40,
     observationalMemory: {
       // Thread scope, NOT resource scope. Async consolidation buffering
       // exists ONLY under thread scope — Mastra's validateBufferConfig throws


### PR DESCRIPTION
## What

The exponential chat route (`src/app/api/chat/stream/route.ts`, PR positonic/exponential#188) now sends **only the latest user message** to `agent.stream()` and relies on thread memory to supply prior turns, instead of re-sending the full client transcript (previously trimmed to ~20k tokens).

But our `Memory` config sets no `lastMessages` override (Mastra default: **10**) and `semanticRecall` is **disabled** (no vector store / embedder configured). So `lastMessages` is the *only* recall path. With the default of 10, any conversation longer than ~5 turns silently loses mid-conversation context the transcript used to carry — a regression introduced the moment PR #188 merges.

## Change

Set `lastMessages: 40` to restore parity with the prior ~20k-token working set.

## Why this matters / deploy ordering

PR #188 depends on this. Until this lands **and is deployed**, the brain recalls only the last 10 messages — so this should be deployed alongside (or before) #188 reaches users to fully close the High finding.

## Verification

- `tsc --noEmit` clean.
- Follow-up: confirm a >10-message thread keeps early-turn context after deploy.