### PR TITLE
feat(zoe): post Objective comments from chat (giddy.eel)

### DIFF
--- a/src/mastra/agents/zoe-agent.ts
+++ b/src/mastra/agents/zoe-agent.ts
@@ -53,6 +53,7 @@ import {
   getOkrStatsTool,
   linkProjectToGoalTool,
   unlinkProjectFromGoalTool,
+  addObjectiveCommentTool,
   // Project & Action management tools
   createProjectTool,
   updateActionTool,
@@ -199,6 +200,15 @@ You can manage the user's OKR system — objectives are qualitative goals, key r
 - **delete-okr-key-result**: Delete a key result (ALWAYS confirm first)
 - **checkin-okr-key-result**: Record a progress check-in — updates value and auto-calculates status
 - **get-okr-stats**: Dashboard stats: totals, status breakdown, average progress
+- **add-objective-comment**: Post a narrative comment (a NOTE, no health, never moves the status badge) to an Objective's activity feed on the user's behalf. Use for narrative notes — a strategy summary, context, a recap of what was agreed — NOT for status/progress statements. Takes the goalId from the page context.
+
+**Posting to an Objective's activity feed:**
+
+When the user is viewing an Objective (the goal detail page injects the current goalId, title, description, why, and status into your context) and asks you to "add this", "post this", "record this", or "write an update/note for this goal", you can post to its activity feed:
+- Use **add-objective-comment** for a narrative note (a strategy summary, context, a recap) — it carries no health and never moves the status badge. This is the right choice for "write our high-level strategy and add it to this goal".
+- ALWAYS draft the text first and show it to the user. Post ONLY after they explicitly confirm (yes, go ahead, post it). Never post to the shared activity feed without confirmation.
+- Use the goalId from the page context — don't ask the user which Objective they mean when you already know.
+- After posting, tell the user it's done and which Objective it landed on.
 
 **OKR Policies:**
 - OKRs live in Exponential's OKR system — NOT in Notion, NOT as project goals, NOT as actions. Never offer alternative save locations for OKR data.
@@ -361,6 +371,7 @@ Use this to decide which tool to call:
 | "Save a key result..." / "Add a KR for..." / "Add a key result to [objective]..." / any mention of KR + objective name | get-okr-objectives (find the matching objective) → VALIDATE KR against best practices (measurable outcome, not an initiative) → CONFIRM details → create-okr-key-result |
 | "I completed 30% of [KR]" / "Update progress on [KR]" | get-okr-objectives (find KR) → checkin-okr-key-result |
 | "How are my OKRs doing?" / "OKR dashboard" | get-okr-stats + get-okr-objectives (parallel) |
+| (while viewing an Objective) "Add this as a comment/note to the goal" / "Post this strategy to this objective" | DRAFT the text, show it, then add-objective-comment (using the page-context goalId) after explicit confirmation |
 | "Delete [objective/KR]" | ALWAYS confirm first → delete-okr-objective or delete-okr-key-result |
 | "What's happening in Slack?" / "Slack updates?" | list-slack-channels → get-slack-channel-history for top channels |
 | "What's the latest in #[channel]?" | list-slack-channels (find ID) → get-slack-channel-history |
@@ -524,6 +535,7 @@ const zoeTools = {
     getOkrStatsTool,
     linkProjectToGoalTool,
     unlinkProjectFromGoalTool,
+    addObjectiveCommentTool,
     // Slack tools
     sendSlackMessageTool,
     updateSlackMessageTool,

--- a/src/mastra/tools/index.ts
+++ b/src/mastra/tools/index.ts
@@ -2487,7 +2487,7 @@ export { notionTools, notionSearchTool, notionGetPageTool, notionQueryDatabaseTo
 export { checkEmailConnectionTool, getRecentEmailsTool, getEmailByIdTool, searchEmailsTool, sendEmailTool, replyToEmailTool } from "./email-tools.js";
 
 // OKR tools
-export { getOkrObjectivesTool, createOkrObjectiveTool, updateOkrObjectiveTool, deleteOkrObjectiveTool, createOkrKeyResultTool, updateOkrKeyResultTool, deleteOkrKeyResultTool, checkInOkrKeyResultTool, getOkrStatsTool, linkProjectToGoalTool, unlinkProjectFromGoalTool } from "./okr-tools.js";
+export { getOkrObjectivesTool, createOkrObjectiveTool, updateOkrObjectiveTool, deleteOkrObjectiveTool, createOkrKeyResultTool, updateOkrKeyResultTool, deleteOkrKeyResultTool, checkInOkrKeyResultTool, getOkrStatsTool, linkProjectToGoalTool, unlinkProjectFromGoalTool, addObjectiveCommentTool } from "./okr-tools.js";
 
 // Project & Action management tools
 export { createProjectTool, updateActionTool, deleteProjectTool, getUserWorkspacesTool, bulkCreateWorkspaceStructureTool } from "./project-tools.js";

--- a/src/mastra/tools/okr-tools.test.ts
+++ b/src/mastra/tools/okr-tools.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the authenticated tRPC transport so the tool's execute can be exercised
+// without a running backend. We assert the tool maps its arguments onto the
+// correct mastra endpoint.
+const authenticatedTrpcCall = vi.fn();
+vi.mock('../utils/authenticated-fetch.js', () => ({
+  authenticatedTrpcCall: (...args: unknown[]) => authenticatedTrpcCall(...args),
+}));
+
+const { addObjectiveCommentTool } = await import('./okr-tools.js');
+
+function makeRequestContext(overrides: Record<string, string> = {}) {
+  const map = new Map<string, string>([
+    ['authToken', 'token-123'],
+    ['userId', 'user-1'],
+    ...Object.entries(overrides),
+  ]);
+  return map;
+}
+
+describe('addObjectiveCommentTool', () => {
+  beforeEach(() => {
+    authenticatedTrpcCall.mockReset();
+  });
+
+  it('calls mastra.addGoalComment with the mapped arguments', async () => {
+    const created = {
+      id: 'c1',
+      goalId: 42,
+      authorId: 'user-1',
+      content: 'Strategy summary',
+      createdAt: '2026-06-14T00:00:00.000Z',
+    };
+    authenticatedTrpcCall.mockResolvedValue({ data: created });
+
+    const result = await addObjectiveCommentTool.execute!(
+      { goalId: 42, content: 'Strategy summary' },
+      { requestContext: makeRequestContext() } as never,
+    );
+
+    expect(authenticatedTrpcCall).toHaveBeenCalledTimes(1);
+    expect(authenticatedTrpcCall).toHaveBeenCalledWith(
+      'mastra.addGoalComment',
+      { goalId: 42, content: 'Strategy summary' },
+      expect.objectContaining({ authToken: 'token-123', userId: 'user-1' }),
+    );
+    expect(result).toEqual(created);
+  });
+
+  it('throws when no auth token is present', async () => {
+    await expect(
+      addObjectiveCommentTool.execute!(
+        { goalId: 42, content: 'x' },
+        { requestContext: new Map() } as never,
+      ),
+    ).rejects.toThrow(/authentication token/i);
+    expect(authenticatedTrpcCall).not.toHaveBeenCalled();
+  });
+});

--- a/src/mastra/tools/okr-tools.ts
+++ b/src/mastra/tools/okr-tools.ts
@@ -387,6 +387,46 @@ export const getOkrStatsTool = createTool({
   },
 });
 
+export const addObjectiveCommentTool = createTool({
+  id: "add-objective-comment",
+  description:
+    "Post a narrative comment to an Objective's (goal's) activity feed on the user's behalf. A comment is a NOTE with NO health — it never moves the Objective's status badge. Use this for narrative notes (a strategy summary, context, a recap of what was agreed), NOT for status/progress statements (use a check-in or an Objective update for those). The Objective the user is viewing is provided in the page context as goalId — use it directly; do not ask for the Objective name. CRITICAL: ALWAYS draft the comment text and show it to the user, then post ONLY after they explicitly confirm. After posting, tell the user it's done and which Objective it landed on.",
+  inputSchema: z.object({
+    goalId: z.number().describe("The numeric ID of the Objective (goal) to comment on — from the page context"),
+    content: z.string().min(1).max(10000).describe("The comment text to post (markdown). Draft this and get the user's explicit confirmation before calling the tool."),
+  }),
+  outputSchema: z.object({
+    id: z.string(),
+    goalId: z.number(),
+    authorId: z.string(),
+    content: z.string(),
+    createdAt: z.string(),
+    author: z.object({
+      id: z.string(),
+      name: z.string().nullable(),
+      image: z.string().nullable(),
+    }).nullable().optional(),
+  }),
+  async execute(inputData, { requestContext }) {
+    const authToken = requestContext?.get("authToken") as string | undefined;
+    const sessionId = requestContext?.get("whatsappSession") as string | undefined;
+    const userId = requestContext?.get("userId") as string | undefined;
+
+    if (!authToken) throw new Error("No authentication token available");
+
+    console.log(`💬 [addObjectiveComment] Posting comment to objective ${inputData.goalId}`);
+
+    const { data } = await authenticatedTrpcCall(
+      "mastra.addGoalComment",
+      { goalId: inputData.goalId, content: inputData.content },
+      { authToken, sessionId, userId }
+    );
+
+    console.log(`✅ [addObjectiveComment] Posted comment ${(data as any)?.id} to objective ${inputData.goalId}`);
+    return data;
+  },
+});
+
 export const linkProjectToGoalTool = createTool({
   id: "link-project-to-goal",
   description:


### PR DESCRIPTION
## What

Adds `addObjectiveCommentTool` so **Zoe** can post a narrative **Objective comment** (`GoalComment` — no health, never moves the status badge) to the activity feed of the Objective the user is viewing, on their behalf.

This is the mastra-side half of Exponential ticket **giddy.eel** (#106). It pairs with the exponential PR that adds `goalService.createGoalComment` + the `mastra.addGoalComment` proxy.

## Changes

- **`okr-tools.ts`** — `addObjectiveCommentTool`: calls `mastra.addGoalComment` via the authenticated tRPC pattern, taking `goalId` (from page context) + `content`.
- **`tools/index.ts`** — export the tool.
- **`zoe-agent.ts`** — register on `zoeAgent` and `zoeAgentHaiku`; instructions to choose a comment for narrative notes, draft the text and require explicit confirmation before posting, and report which Objective it landed on.
- **`okr-tools.test.ts`** — asserts the mapped endpoint/arguments and the no-auth guard.

## Testing

- `npx vitest run` — all tests pass (incl. new tool test).
- `npx tsc --noEmit` — clean.

## Notes

Depends on the exponential `mastra.addGoalComment` endpoint shipping. Access is enforced server-side by `verifyGoalAccess`; the injected `goalId` is supplementary client context. See ADR-0016.