### PR TITLE
fix(zoe): coerce goalId on objective comment/update tools

### DIFF
--- a/src/mastra/tools/okr-tools.test.ts
+++ b/src/mastra/tools/okr-tools.test.ts
@@ -57,6 +57,14 @@ describe('addObjectiveCommentTool', () => {
     ).rejects.toThrow(/authentication token/i);
     expect(authenticatedTrpcCall).not.toHaveBeenCalled();
   });
+
+  it('coerces a string goalId to a number (the model emits it as text)', () => {
+    const parsed = addObjectiveCommentTool.inputSchema!.parse({
+      goalId: '19',
+      content: 'Strategy summary',
+    });
+    expect(parsed.goalId).toBe(19);
+  });
 });
 
 describe('addObjectiveUpdateTool', () => {
@@ -97,5 +105,14 @@ describe('addObjectiveUpdateTool', () => {
       ),
     ).rejects.toThrow(/authentication token/i);
     expect(authenticatedTrpcCall).not.toHaveBeenCalled();
+  });
+
+  it('coerces a string goalId to a number (the model emits it as text)', () => {
+    const parsed = addObjectiveUpdateTool.inputSchema!.parse({
+      goalId: '19',
+      content: 'Slipping on the launch',
+      health: 'at-risk',
+    });
+    expect(parsed.goalId).toBe(19);
   });
 });

--- a/src/mastra/tools/okr-tools.ts
+++ b/src/mastra/tools/okr-tools.ts
@@ -392,7 +392,7 @@ export const addObjectiveCommentTool = createTool({
   description:
     "Post a narrative comment to an Objective's (goal's) activity feed on the user's behalf. A comment is a NOTE with NO health — it never moves the Objective's status badge. Use this for narrative notes (a strategy summary, context, a recap of what was agreed), NOT for status/progress statements (use a check-in or an Objective update for those). The Objective the user is viewing is provided in the page context as goalId — use it directly; do not ask for the Objective name. CRITICAL: ALWAYS draft the comment text and show it to the user, then post ONLY after they explicitly confirm. After posting, tell the user it's done and which Objective it landed on.",
   inputSchema: z.object({
-    goalId: z.number().describe("The numeric ID of the Objective (goal) to comment on — from the page context"),
+    goalId: z.coerce.number().describe("The numeric ID of the Objective (goal) to comment on — from the page context. Coerced from string because the model often emits it as text lifted from the prompt."),
     content: z.string().min(1).max(10000).describe("The comment text to post (markdown). Draft this and get the user's explicit confirmation before calling the tool."),
   }),
   outputSchema: z.object({
@@ -432,7 +432,7 @@ export const addObjectiveUpdateTool = createTool({
   description:
     "Post a health-bearing update (check-in) to an Objective's (goal's) activity feed on the user's behalf. An update carries a HEALTH (on-track | at-risk | off-track) and MOVES the Objective's status badge — use it for status/progress statements (\"we're behind on this\", \"back on track\"), NOT for narrative notes (use add-objective-comment for those). The Objective the user is viewing is provided in the page context as goalId — use it directly. Infer the health from the conversation; when there is no clear signal, default to the Objective's CURRENT health (shown as \"Current health\" in your goal page context) so a narrative-ish update never silently flips the status. CRITICAL: ALWAYS draft both the update text AND the health value you will set, show them to the user, and post ONLY after they explicitly confirm. Never set a manual status override — that stays the user's \"Set status\" action. After posting, tell the user it's done, which Objective, and the health you set.",
   inputSchema: z.object({
-    goalId: z.number().describe("The numeric ID of the Objective (goal) to update — from the page context"),
+    goalId: z.coerce.number().describe("The numeric ID of the Objective (goal) to update — from the page context. Coerced from string because the model often emits it as text lifted from the prompt."),
     content: z.string().min(1).max(10000).describe("The update text (markdown). Draft this and get the user's explicit confirmation before calling the tool."),
     health: z.enum(["on-track", "at-risk", "off-track"]).describe("The health this check-in sets — moves the status badge. Infer from the conversation; default to the Objective's current health when unclear. Show it in the draft and confirm before posting."),
   }),


### PR DESCRIPTION
## Problem

When a user on an Objective page asks Zoe to post an update/comment, the tool call fails: Zoe loops on "goalId needs to be a number" / "expecting the goalId in a different format" and gives up, telling the user to add it manually.

**Root cause:** the model lifts `goalId` from the page-context text in the system prompt (`Goal: … (ID: 19)`) and emits it as a **string**. `addObjectiveCommentTool` / `addObjectiveUpdateTool` declared `goalId: z.number()`, so the AI-SDK/zod validation rejected the argument *before* `execute()` ran. Every other agent tool either takes string ids (CUIDs) or sources numbers from a prior tool result, so `goalId` is the first numeric arg sourced directly from prompt text — the first to trip strict `z.number()`.

## Fix

`z.number()` → `z.coerce.number()` for `goalId` on both tools, so `"19"` and `19` both validate. Added regression tests asserting the `inputSchema` coerces a string `goalId`.

The wire format (superjson `{json, meta}`) and the server access logic were verified correct and are unchanged — the fix is purely the agent-boundary input validation.

The exponential-side proxies (`mastra.addGoalComment` / `mastra.addGoalUpdate`) get the same coercion as defense-in-depth in a companion PR.

## Test

`npx vitest run src/mastra/tools/okr-tools.test.ts` — 6 passed (incl. 2 new coercion tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases validating `goalId` input coercion behavior for objective management tools

* **Bug Fixes**
  * Objective management tools now accept `goalId` as both string and numeric values, improving input compatibility and flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->