### PR TITLE
feat(zoe): let the agent build goal hierarchy (parent/sub-goals)

### DIFF
--- a/src/mastra/agents/zoe-agent.ts
+++ b/src/mastra/agents/zoe-agent.ts
@@ -53,6 +53,7 @@ import {
   getOkrStatsTool,
   linkProjectToGoalTool,
   unlinkProjectFromGoalTool,
+  linkObjectiveToParentTool,
   addObjectiveCommentTool,
   addObjectiveUpdateTool,
   // Project & Action management tools
@@ -190,10 +191,14 @@ You have access to the user's CRM for relationship management:
 2. Call bulk-create-workspace-structure with the full hierarchy
 3. Report the verified created/failed manifest to the user — never claim success for items not in the manifest
 
+**Goal hierarchy (sub-goals / phases):**
+Goals can nest under a parent goal (up to 5 levels). When the user is viewing a goal — its goalId is in your page context — and asks to "build this structure for this goal", "break this into phases", or "create goals under this goal", you MUST nest the new goals under that goal: pass its id as parentGoalId (per-goal on create-okr-objective, or the batch-level parentGoalId on bulk-create-workspace-structure). Do NOT create orphaned top-level goals when the user means sub-goals. To re-parent goals that already exist, use link-objective-to-parent.
+
 ### OKRs (Objectives & Key Results)
 You can manage the user's OKR system — objectives are qualitative goals, key results are measurable outcomes:
 - **get-okr-objectives**: List all objectives with their key results and progress. Filter by period.
-- **create-okr-objective**: Create a new objective (confirm with user first)
+- **create-okr-objective**: Create a new objective (confirm with user first). Accepts a parentGoalId to nest it under another objective.
+- **link-objective-to-parent**: Nest an existing objective under a parent (or detach with parentGoalId = null) to build a goal hierarchy. Use this to make existing goals into sub-goals/phases of a north-star goal.
 - **update-okr-objective**: Update an objective's title, description, period, etc.
 - **delete-okr-objective**: Delete an objective and all its KRs (ALWAYS confirm first — irreversible)
 - **create-okr-key-result**: Create a key result linked to an objective (confirm details first)
@@ -546,6 +551,7 @@ const zoeTools = {
     getOkrStatsTool,
     linkProjectToGoalTool,
     unlinkProjectFromGoalTool,
+    linkObjectiveToParentTool,
     addObjectiveCommentTool,
     addObjectiveUpdateTool,
     // Slack tools

--- a/src/mastra/tools/index.ts
+++ b/src/mastra/tools/index.ts
@@ -2487,7 +2487,7 @@ export { notionTools, notionSearchTool, notionGetPageTool, notionQueryDatabaseTo
 export { checkEmailConnectionTool, getRecentEmailsTool, getEmailByIdTool, searchEmailsTool, sendEmailTool, replyToEmailTool } from "./email-tools.js";
 
 // OKR tools
-export { getOkrObjectivesTool, createOkrObjectiveTool, updateOkrObjectiveTool, deleteOkrObjectiveTool, createOkrKeyResultTool, updateOkrKeyResultTool, deleteOkrKeyResultTool, checkInOkrKeyResultTool, getOkrStatsTool, linkProjectToGoalTool, unlinkProjectFromGoalTool, addObjectiveCommentTool, addObjectiveUpdateTool } from "./okr-tools.js";
+export { getOkrObjectivesTool, createOkrObjectiveTool, updateOkrObjectiveTool, deleteOkrObjectiveTool, createOkrKeyResultTool, updateOkrKeyResultTool, deleteOkrKeyResultTool, checkInOkrKeyResultTool, getOkrStatsTool, linkProjectToGoalTool, unlinkProjectFromGoalTool, linkObjectiveToParentTool, addObjectiveCommentTool, addObjectiveUpdateTool } from "./okr-tools.js";
 
 // Project & Action management tools
 export { createProjectTool, updateActionTool, deleteProjectTool, getUserWorkspacesTool, bulkCreateWorkspaceStructureTool } from "./project-tools.js";

--- a/src/mastra/tools/okr-tools.ts
+++ b/src/mastra/tools/okr-tools.ts
@@ -71,6 +71,7 @@ export const createOkrObjectiveTool = createTool({
     whyThisGoal: z.string().optional().describe("Why this objective matters"),
     period: z.string().optional().describe("OKR period (e.g., 'Q1-2026', 'H1-2026', 'Annual-2026')"),
     lifeDomainId: looseNumber().optional().describe("Life domain ID to categorize this objective"),
+    parentGoalId: looseNumber().optional().describe("Parent objective (goal) ID to nest this under. When the user is viewing a goal and asks to create goals 'under this goal' / as phases of it, use that goal's ID (from the page context) here."),
   }),
   outputSchema: z.object({
     objective: z.object({
@@ -78,6 +79,7 @@ export const createOkrObjectiveTool = createTool({
       title: z.string(),
       description: z.string().nullable(),
       period: z.string().nullable(),
+      parentGoalId: z.number().nullable(),
       lifeDomain: z.object({ id: z.number(), title: z.string() }).nullable(),
       workspaceId: z.string().nullable(),
     }),
@@ -499,6 +501,42 @@ export const linkProjectToGoalTool = createTool({
     );
 
     console.log(`✅ [linkProjectToGoal] Success`);
+    return data;
+  },
+});
+
+export const linkObjectiveToParentTool = createTool({
+  id: "link-objective-to-parent",
+  description:
+    "Nest an Objective (goal) under a parent Objective to build a goal hierarchy — e.g. make existing goals into sub-goals/phases of a north-star goal. Both are numeric goal IDs. To detach a goal (make it top-level again), pass parentGoalId = null. The backend rejects cycles and nesting deeper than 5 levels.",
+  inputSchema: z.object({
+    goalId: looseNumber().describe("The numeric ID of the Objective (goal) to re-parent"),
+    parentGoalId: looseNumber().nullable().describe("The numeric ID of the parent Objective to nest under, or null to detach (make top-level)"),
+  }),
+  outputSchema: z.object({
+    objective: z.object({
+      id: z.number(),
+      title: z.string(),
+      parentGoalId: z.number().nullable(),
+      parentGoal: z.object({ id: z.number(), title: z.string() }).nullable(),
+    }),
+  }),
+  async execute(inputData, { requestContext }) {
+    const authToken = requestContext?.get("authToken") as string | undefined;
+    const sessionId = requestContext?.get("whatsappSession") as string | undefined;
+    const userId = requestContext?.get("userId") as string | undefined;
+
+    if (!authToken) throw new Error("No authentication token available");
+
+    console.log(`🔗 [linkObjectiveToParent] Nesting goal ${inputData.goalId} under ${inputData.parentGoalId}`);
+
+    const { data } = await authenticatedTrpcCall(
+      "mastra.setObjectiveParent",
+      { goalId: inputData.goalId, parentGoalId: inputData.parentGoalId },
+      { authToken, sessionId, userId }
+    );
+
+    console.log(`✅ [linkObjectiveToParent] Success`);
     return data;
   },
 });

--- a/src/mastra/tools/project-tools.ts
+++ b/src/mastra/tools/project-tools.ts
@@ -1,6 +1,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
+import { looseNumber } from "./zod-loose.js";
 
 // ==================== Project & Action Management Tools ====================
 // Tools for creating projects and updating actions (including moving between projects).
@@ -214,9 +215,11 @@ export const bulkCreateWorkspaceStructureTool = createTool({
     "Create a complete hierarchy of goals, projects, and actions in a single atomic operation. Use this when the user provides a structured list of goals with associated projects and actions — it's far more reliable than creating items one by one. Returns a manifest of everything created and anything that failed, so you can give the user an accurate verified summary.",
   inputSchema: z.object({
     workspaceId: z.string().describe("The ID of the workspace to create items in — use get-user-workspaces to find it"),
+    parentGoalId: looseNumber().optional().describe("Optional parent objective (goal) ID: nest EVERY created goal under this one unless a goal sets its own parentGoalId. When the user is viewing a goal and asks to build a structure 'under this goal' / as phases of it, pass that goal's ID (from the page context) here."),
     goals: z.array(z.object({
       title: z.string().describe("Goal/objective title"),
       description: z.string().optional().describe("Goal description"),
+      parentGoalId: looseNumber().optional().describe("Optional parent objective (goal) ID for THIS goal specifically; overrides the batch-level parentGoalId."),
       projects: z.array(z.object({
         name: z.string().describe("Project name"),
         description: z.string().optional().describe("Project description"),

--- a/src/mastra/tools/tool-input-coercion.test.ts
+++ b/src/mastra/tools/tool-input-coercion.test.ts
@@ -21,9 +21,15 @@ const parseInput = (
 ): Record<string, unknown> =>
   (tool.inputSchema as z.ZodTypeAny).parse(value) as Record<string, unknown>;
 
-const { createOkrKeyResultTool, updateOkrObjectiveTool, checkInOkrKeyResultTool } =
-  await import('./okr-tools.js');
+const {
+  createOkrKeyResultTool,
+  updateOkrObjectiveTool,
+  checkInOkrKeyResultTool,
+  createOkrObjectiveTool,
+  linkObjectiveToParentTool,
+} = await import('./okr-tools.js');
 const { getAllProjectsTool } = await import('./index.js');
+const { bulkCreateWorkspaceStructureTool } = await import('./project-tools.js');
 
 describe('tool input coercion — the model emits scalars as strings', () => {
   it('getAllProjectsTool.includeAll: string "false" stays false (NOT the z.coerce.boolean footgun)', () => {
@@ -61,5 +67,35 @@ describe('tool input coercion — the model emits scalars as strings', () => {
 
   it('still rejects genuine garbage (coercion is not blind acceptance)', () => {
     expect(() => parseInput(checkInOkrKeyResultTool, { keyResultId: 'kr_1', newValue: 'banana' })).toThrow();
+  });
+});
+
+describe('goal hierarchy — parentGoalId coercion', () => {
+  it('createOkrObjectiveTool coerces a string parentGoalId', () => {
+    const parsed = parseInput(createOkrObjectiveTool, { title: 'Phase 0', parentGoalId: '19' });
+    expect(parsed.parentGoalId).toBe(19);
+  });
+
+  it('createOkrObjectiveTool allows omitting parentGoalId (top-level goal)', () => {
+    const parsed = parseInput(createOkrObjectiveTool, { title: 'North star' });
+    expect(parsed.parentGoalId).toBeUndefined();
+  });
+
+  it('linkObjectiveToParentTool coerces a string parentGoalId and accepts null to detach', () => {
+    expect(parseInput(linkObjectiveToParentTool, { goalId: '70', parentGoalId: '19' })).toMatchObject({
+      goalId: 70,
+      parentGoalId: 19,
+    });
+    expect(parseInput(linkObjectiveToParentTool, { goalId: '70', parentGoalId: null }).parentGoalId).toBeNull();
+  });
+
+  it('bulkCreateWorkspaceStructureTool coerces parentGoalId at batch and per-goal level', () => {
+    const parsed = parseInput(bulkCreateWorkspaceStructureTool, {
+      workspaceId: 'ws_1',
+      parentGoalId: '19',
+      goals: [{ title: 'Phase 1', parentGoalId: '20' }],
+    });
+    expect(parsed.parentGoalId).toBe(19);
+    expect((parsed.goals as Array<{ parentGoalId: number }>)[0]!.parentGoalId).toBe(20);
   });
 });


### PR DESCRIPTION
## Problem

A user viewing Goal 19 asked Zoe to build a strategy "in this goal." Zoe created 10 **orphaned top-level** goals instead of nesting them under Goal 19 — the user expected sub-goals, got siblings. The agent had no way to express goal-to-goal parentage.

The backend already fully supports hierarchy (`Goal.parentGoalId`, 5-level depth cap, cycle prevention, health roll-up) — the gap was purely the agent tools.

## Changes

- **`createOkrObjectiveTool`**: accepts `parentGoalId` (looseNumber).
- **`bulkCreateWorkspaceStructureTool`**: a batch-level `parentGoalId` (nest all created goals) + per-goal `parentGoalId` override. This is the exact gap that caused the incident.
- **New `linkObjectiveToParentTool`**: nest an existing objective under a parent, or detach with `parentGoalId = null`. Registered on `zoeAgent`, exported from the barrel.
- **Zoe instructions**: when the user is viewing a goal (its `goalId` is in page context) and asks to "build this under this goal" / "break into phases", nest under that goal — don't create orphaned top-level goals.

All numeric inputs use `looseNumber()` per the agent-tool-input convention.

## Pairs with

exponential PR (companion) — wires `parentGoalId` through `mastra.createOkrObjective` / `bulkCreateStructure`, adds `mastra.setObjectiveParent` (non-destructive, via a new `goalService.setGoalParent`), and shows parent/sub-goals on the goal detail page.

## Test

`vitest run src/mastra/tools/` — 15 passed (incl. new `parentGoalId` coercion + null-detach cases). `tsc --noEmit` — 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added goal hierarchy support: objectives can now be nested up to 5 levels deep under parent objectives
  * New capability to link existing objectives to parent goals or detach them for flexible goal structure reorganization
  * Batch goal creation now supports parent goal assignment at both batch and individual goal levels

* **Documentation**
  * Updated AI system prompt with goal hierarchy specifications and nesting guidelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->