### PR TITLE
feat(notion): search tool via authenticated callback (ADR-0020)

### DIFF
--- a/src/mastra/tools/notion-tools.test.ts
+++ b/src/mastra/tools/notion-tools.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the authenticated tRPC transport so the tool's execute can be exercised
+// without a running backend. We assert the tool maps its arguments onto the
+// correct mastra endpoint (the ADR-0020 authenticated-callback shape) — the
+// Notion credential is resolved server-side and never reaches this tool.
+const authenticatedTrpcCall = vi.fn();
+vi.mock('../utils/authenticated-fetch.js', () => ({
+  authenticatedTrpcCall: (...args: unknown[]) => authenticatedTrpcCall(...args),
+}));
+
+const { notionSearchTool } = await import('./notion-tools.js');
+
+function makeRequestContext(overrides: Record<string, string> = {}) {
+  return new Map<string, string>([
+    ['authToken', 'token-123'],
+    ['userId', 'user-1'],
+    ['workspaceId', 'ws-1'],
+    ...Object.entries(overrides),
+  ]);
+}
+
+describe('notionSearchTool', () => {
+  beforeEach(() => {
+    authenticatedTrpcCall.mockReset();
+  });
+
+  it('calls mastra.notionSearch with the mapped arguments + workspaceId from context', async () => {
+    const serverResult = {
+      connected: true,
+      total: 1,
+      results: [{ id: 'p1', type: 'page', title: 'Payments', url: 'https://notion.so/p1' }],
+      hasMore: false,
+    };
+    authenticatedTrpcCall.mockResolvedValue({ data: serverResult });
+
+    const result = await notionSearchTool.execute!(
+      { query: 'payments', filter: 'database' },
+      { requestContext: makeRequestContext() } as never,
+    );
+
+    expect(authenticatedTrpcCall).toHaveBeenCalledTimes(1);
+    expect(authenticatedTrpcCall).toHaveBeenCalledWith(
+      'mastra.notionSearch',
+      { query: 'payments', filter: 'database', workspaceId: 'ws-1' },
+      expect.objectContaining({ authToken: 'token-123', userId: 'user-1' }),
+    );
+    expect(result).toEqual(serverResult);
+  });
+
+  it('passes workspaceId: undefined when none is in context', async () => {
+    authenticatedTrpcCall.mockResolvedValue({ data: { connected: false } });
+
+    await notionSearchTool.execute!(
+      { query: 'anything' },
+      { requestContext: new Map([['authToken', 't'], ['userId', 'u']]) } as never,
+    );
+
+    expect(authenticatedTrpcCall).toHaveBeenCalledWith(
+      'mastra.notionSearch',
+      { query: 'anything', filter: undefined, workspaceId: undefined },
+      expect.objectContaining({ authToken: 't', userId: 'u' }),
+    );
+  });
+
+  it('throws when no auth token is present (never reaches the backend)', async () => {
+    await expect(
+      notionSearchTool.execute!(
+        { query: 'x' },
+        { requestContext: new Map() } as never,
+      ),
+    ).rejects.toThrow(/authentication token/i);
+    expect(authenticatedTrpcCall).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a backend failure as an { error } result', async () => {
+    authenticatedTrpcCall.mockRejectedValue(new Error('boom'));
+
+    const result = await notionSearchTool.execute!(
+      { query: 'x' },
+      { requestContext: makeRequestContext() } as never,
+    );
+
+    expect(result).toEqual({ error: 'boom' });
+  });
+});

--- a/src/mastra/tools/notion-tools.ts
+++ b/src/mastra/tools/notion-tools.ts
@@ -7,6 +7,7 @@ import { Client, LogLevel, isNotionClientError, ClientErrorCode, APIErrorCode } 
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { prepareUntrustedContent } from "../utils/content-safety.js";
+import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
 
 // ---------------------------------------------------------------------------
 // Client — the SDK handles retries (3 attempts with backoff) and rate-limit
@@ -172,40 +173,34 @@ function formatError(err: unknown): string {
 
 export const notionSearchTool = createTool({
   id: "notion-search",
-  description: "Search for pages and databases in Notion by title or content",
+  description:
+    "Search the user's Notion for pages and databases by title or content. The Notion credential is resolved server-side from the user's connected integration — you never see it. Returns a lean list of {id, type, title, url}. " +
+    "If the result is `{connected:false}`, the user has not connected Notion — tell them to connect it in Settings → Integrations. " +
+    "If `{connected:true, total:0}` (no matches), the most likely cause is that a Notion internal integration only sees pages explicitly SHARED with it — tell the user to open the page/database in Notion, click '•••' → 'Connections' (or 'Add connections') and share it with the integration, then try again. " +
+    "Use the returned page/database `id` with notion-get-page or notion-query-database.",
   inputSchema: z.object({
     query: z.string().describe("Search query"),
     filter: z.enum(["page", "database"]).optional().describe("Filter by object type"),
   }),
   execute: async (inputData, { requestContext }) => {
+    const authToken = requestContext?.get("authToken") as string | undefined;
+    const userId = requestContext?.get("userId") as string | undefined;
+    const sessionId = requestContext?.get("whatsappSession") as string | undefined;
+    const workspaceId = requestContext?.get("workspaceId") as string | undefined;
+
+    if (!authToken) throw new Error("No authentication token available");
+
     try {
-      const client = getClientFromRuntime(requestContext);
-      const { query, filter } = inputData;
-
-      // SDK v5 renamed "database" → "data_source" in the filter type
-      const body: Parameters<typeof client.search>[0] = { query };
-      if (filter) {
-        body.filter = {
-          value: filter === "database" ? "data_source" : "page",
-          property: "object",
-        };
-      }
-
-      const response = await client.search(body);
-
-      return {
-        results: response.results.map((r: any) => ({
-          id: r.id,
-          type: r.object,
-          title:
-            r.object === "page"
-              ? extractPageTitle(r.properties ?? {})
-              : r.title?.[0]?.plain_text ?? "Untitled",
-          url: r.url,
-        })),
-        total: response.results.length,
-        hasMore: response.has_more,
-      };
+      const { data } = await authenticatedTrpcCall(
+        "mastra.notionSearch",
+        {
+          query: inputData.query,
+          filter: inputData.filter,
+          workspaceId: workspaceId || undefined,
+        },
+        { authToken, sessionId, userId },
+      );
+      return data;
     } catch (err) {
       return { error: formatError(err) };
     }


### PR DESCRIPTION
Companion to exponential's cobalt.spire (#131) Notion-search foundation slice.

Rewrites `notionSearchTool` to carry only the agent JWT and call back into exponential's new `mastra.notionSearch` endpoint, which resolves the user's Notion credential **server-side** (ADR-0020). The credential no longer enters the LLM context.

- `notionSearchTool` execute: reads `authToken`/`userId`/`workspaceId` from requestContext, calls `authenticatedTrpcCall('mastra.notionSearch', …)`.
- Description coaches Zoe on the two dead-ends: `connected:false` → connect in Settings → Integrations; `connected:true, total:0` → the internal integration only sees pages explicitly **shared with it**.
- `getClientFromRuntime` stays for the four un-migrated tools (get-page, query-database, create/update) until their sibling tickets land.
- Adds `notion-tools.test.ts`: arg mapping, workspaceId passthrough, no-auth-token guard, backend-error surfacing.

Verified with `npx tsc` (0 errors) and `vitest` (4/4).

**Merge ordering:** land alongside the exponential PR — the search tool 404s until `mastra.notionSearch` is deployed.