### PR TITLE
feat(notion): query-database tool via authenticated callback (ADR-0020)

### DIFF
--- a/src/mastra/tools/notion-tools.test.ts
+++ b/src/mastra/tools/notion-tools.test.ts
@@ -9,7 +9,7 @@ vi.mock('../utils/authenticated-fetch.js', () => ({
   authenticatedTrpcCall: (...args: unknown[]) => authenticatedTrpcCall(...args),
 }));
 
-const { notionSearchTool } = await import('./notion-tools.js');
+const { notionSearchTool, notionQueryDatabaseTool } = await import('./notion-tools.js');
 
 function makeRequestContext(overrides: Record<string, string> = {}) {
   return new Map<string, string>([
@@ -82,5 +82,84 @@ describe('notionSearchTool', () => {
     );
 
     expect(result).toEqual({ error: 'boom' });
+  });
+});
+
+describe('notionQueryDatabaseTool', () => {
+  beforeEach(() => {
+    authenticatedTrpcCall.mockReset();
+  });
+
+  it('calls mastra.notionQueryDatabase with the mapped arguments + workspaceId', async () => {
+    authenticatedTrpcCall.mockResolvedValue({
+      data: { connected: true, total: 0, hasMore: false, nextCursor: null, rows: [] },
+    });
+
+    await notionQueryDatabaseTool.execute!(
+      {
+        databaseId: 'db-1',
+        sorts: [{ property: 'Due', direction: 'ascending' }],
+        startCursor: 'cur-1',
+      },
+      { requestContext: makeRequestContext() } as never,
+    );
+
+    expect(authenticatedTrpcCall).toHaveBeenCalledWith(
+      'mastra.notionQueryDatabase',
+      {
+        databaseId: 'db-1',
+        filter: undefined,
+        sorts: [{ property: 'Due', direction: 'ascending' }],
+        startCursor: 'cur-1',
+        workspaceId: 'ws-1',
+      },
+      expect.objectContaining({ authToken: 'token-123', userId: 'user-1' }),
+    );
+  });
+
+  it('wraps returned row content (untrusted) and preserves the lean shape', async () => {
+    authenticatedTrpcCall.mockResolvedValue({
+      data: {
+        connected: true,
+        total: 1,
+        hasMore: true,
+        nextCursor: 'cur-2',
+        rows: [{ id: 'r1', title: 'Rent', url: 'https://notion.so/r1', props: { Amount: 1200 } }],
+      },
+    });
+
+    const result = (await notionQueryDatabaseTool.execute!(
+      { databaseId: 'db-1' },
+      { requestContext: makeRequestContext() } as never,
+    )) as any;
+
+    expect(result.connected).toBe(true);
+    expect(result.hasMore).toBe(true);
+    expect(result.nextCursor).toBe('cur-2');
+    expect(result.rows[0].id).toBe('r1');
+    // title is a string (wrapped or not, the value still contains the text)
+    expect(String(result.rows[0].title)).toContain('Rent');
+    expect(result.rows[0].props.Amount).toBe(1200);
+  });
+
+  it('passes {connected:false} through untouched (no rows to wrap)', async () => {
+    authenticatedTrpcCall.mockResolvedValue({ data: { connected: false } });
+
+    const result = await notionQueryDatabaseTool.execute!(
+      { databaseId: 'db-1' },
+      { requestContext: makeRequestContext() } as never,
+    );
+
+    expect(result).toEqual({ connected: false });
+  });
+
+  it('throws when no auth token is present', async () => {
+    await expect(
+      notionQueryDatabaseTool.execute!(
+        { databaseId: 'db-1' },
+        { requestContext: new Map() } as never,
+      ),
+    ).rejects.toThrow(/authentication token/i);
+    expect(authenticatedTrpcCall).not.toHaveBeenCalled();
   });
 });

--- a/src/mastra/tools/notion-tools.ts
+++ b/src/mastra/tools/notion-tools.ts
@@ -282,9 +282,13 @@ export const notionGetPageTool = createTool({
 export const notionQueryDatabaseTool = createTool({
   id: "notion-query-database",
   description:
-    "Query a Notion database with optional filters and sorts. Auto-paginates to fetch all matching results.",
+    "Query one of the user's Notion databases with optional filters and sorts. The Notion credential is resolved server-side — you never see it. " +
+    "Returns at most 25 rows (each {id, title, url, props}, scalar properties only — no long text blobs) plus `hasMore`/`nextCursor`. " +
+    "If `hasMore` is true there are more rows: either tighten the filter/sort, or page by calling again with `startCursor` set to the returned `nextCursor`. Don't try to slurp the whole database. " +
+    "If `{connected:false}`, the user hasn't connected Notion — tell them to connect it in Settings → Integrations. " +
+    "If `{connected:true, total:0}` (no rows), the most likely cause is that a Notion internal integration only sees databases explicitly SHARED with it — tell the user to share the database with the integration in Notion (open it → '•••' → 'Connections'), then retry.",
   inputSchema: z.object({
-    databaseId: z.string().describe("Notion database ID (UUID)"),
+    databaseId: z.string().describe("Notion database ID (UUID), e.g. from notion-search"),
     filter: z.any().optional().describe("Notion filter object — see https://developers.notion.com/reference/post-database-query-filter"),
     sorts: z
       .array(
@@ -295,55 +299,45 @@ export const notionQueryDatabaseTool = createTool({
       )
       .optional()
       .describe("Sort criteria"),
-    maxResults: z
-      .number()
+    startCursor: z
+      .string()
       .optional()
-      .default(200)
-      .describe("Max results to return (default 200). Set lower for faster responses."),
+      .describe("Pagination cursor — pass the `nextCursor` from a previous call to fetch the next page of up to 25 rows"),
   }),
   execute: async (inputData, { requestContext }) => {
+    const authToken = requestContext?.get("authToken") as string | undefined;
+    const userId = requestContext?.get("userId") as string | undefined;
+    const sessionId = requestContext?.get("whatsappSession") as string | undefined;
+    const workspaceId = requestContext?.get("workspaceId") as string | undefined;
+
+    if (!authToken) throw new Error("No authentication token available");
+
     try {
-      const client = getClientFromRuntime(requestContext);
-      const { databaseId, filter, sorts, maxResults = 200 } = inputData;
+      const { data } = await authenticatedTrpcCall(
+        "mastra.notionQueryDatabase",
+        {
+          databaseId: inputData.databaseId,
+          filter: inputData.filter,
+          sorts: inputData.sorts,
+          startCursor: inputData.startCursor,
+          workspaceId: workspaceId || undefined,
+        },
+        { authToken, sessionId, userId },
+      );
 
-      const allResults: any[] = [];
-      let cursor: string | undefined;
+      // Wrap the returned row content — Notion database content is untrusted
+      // external content (content-injection posture, ADR-0020).
+      if (data && (data as any).connected && Array.isArray((data as any).rows)) {
+        (data as any).rows = (data as any).rows.map((row: any) => ({
+          ...row,
+          title: typeof row.title === "string"
+            ? prepareUntrustedContent(row.title, "notion_database")
+            : row.title,
+          props: wrapPropertyValue(row.props, "notion_database"),
+        }));
+      }
 
-      do {
-        const body: Parameters<typeof client.dataSources.query>[0] = {
-          data_source_id: databaseId,
-          page_size: Math.min(100, maxResults - allResults.length),
-          start_cursor: cursor,
-        };
-        if (filter) body.filter = filter;
-        if (sorts) body.sorts = sorts;
-
-        const response = await client.dataSources.query(body);
-        allResults.push(...response.results);
-
-        cursor =
-          response.has_more && allResults.length < maxResults
-            ? (response.next_cursor ?? undefined)
-            : undefined;
-      } while (cursor);
-
-      // Wrap property values — database content is untrusted external content
-      return {
-        results: allResults.map((page: any) => {
-          const props = extractProperties(page.properties ?? {});
-          const wrappedProps: Record<string, unknown> = {};
-          for (const [key, value] of Object.entries(props)) {
-            wrappedProps[key] = wrapPropertyValue(value, "notion_database");
-          }
-          return {
-            id: page.id,
-            url: page.url,
-            properties: wrappedProps,
-          };
-        }),
-        total: allResults.length,
-        capped: allResults.length >= maxResults,
-      };
+      return data;
     } catch (err) {
       return { error: formatError(err) };
     }


### PR DESCRIPTION
Companion to exponential's still.shore (#132) — Notion query-database read slice.

Rewrites `notionQueryDatabaseTool` to carry only the agent JWT and call `mastra.notionQueryDatabase`, which resolves the user's Notion credential **server-side** (ADR-0020) and returns a lean, capped result: ≤25 rows, each `{id, title, url, props}` with **scalar properties only** (no rich-text blobs), plus `hasMore`/`nextCursor`.

- Description coaches Zoe to **page/refine** on `hasMore` (pass `nextCursor` as `startCursor`) rather than slurp the whole database, and carries the connect / shared-pages dead-end coaching.
- Returned row content is wrapped as untrusted external content.
- `getClientFromRuntime` stays for get-page + create/update until their sibling tickets land.

Verified: `npx tsc` (0 errors), `vitest` (8/8).

**Merge alongside** the exponential PR — the tool 404s until `mastra.notionQueryDatabase` is deployed.