### PR TITLE
feat(notion): get-page tool via authenticated callback (ADR-0020)

### DIFF
--- a/src/mastra/tools/notion-tools.test.ts
+++ b/src/mastra/tools/notion-tools.test.ts
@@ -9,7 +9,7 @@ vi.mock('../utils/authenticated-fetch.js', () => ({
   authenticatedTrpcCall: (...args: unknown[]) => authenticatedTrpcCall(...args),
 }));
 
-const { notionSearchTool, notionQueryDatabaseTool } = await import('./notion-tools.js');
+const { notionSearchTool, notionQueryDatabaseTool, notionGetPageTool } = await import('./notion-tools.js');
 
 function makeRequestContext(overrides: Record<string, string> = {}) {
   return new Map<string, string>([
@@ -157,6 +157,66 @@ describe('notionQueryDatabaseTool', () => {
     await expect(
       notionQueryDatabaseTool.execute!(
         { databaseId: 'db-1' },
+        { requestContext: new Map() } as never,
+      ),
+    ).rejects.toThrow(/authentication token/i);
+    expect(authenticatedTrpcCall).not.toHaveBeenCalled();
+  });
+});
+
+describe('notionGetPageTool', () => {
+  beforeEach(() => {
+    authenticatedTrpcCall.mockReset();
+  });
+
+  it('calls mastra.notionGetPage with the pageId + workspaceId from context', async () => {
+    authenticatedTrpcCall.mockResolvedValue({
+      data: { connected: true, id: 'pg-1', title: 'Notes', url: 'https://notion.so/pg-1', text: 'hello', truncated: false },
+    });
+
+    await notionGetPageTool.execute!(
+      { pageId: 'pg-1' },
+      { requestContext: makeRequestContext() } as never,
+    );
+
+    expect(authenticatedTrpcCall).toHaveBeenCalledWith(
+      'mastra.notionGetPage',
+      { pageId: 'pg-1', workspaceId: 'ws-1' },
+      expect.objectContaining({ authToken: 'token-123', userId: 'user-1' }),
+    );
+  });
+
+  it('wraps the returned title + text (untrusted) and keeps the truncated flag', async () => {
+    authenticatedTrpcCall.mockResolvedValue({
+      data: { connected: true, id: 'pg-1', title: 'Notes', url: 'https://notion.so/pg-1', text: 'secret plan', truncated: true },
+    });
+
+    const result = (await notionGetPageTool.execute!(
+      { pageId: 'pg-1' },
+      { requestContext: makeRequestContext() } as never,
+    )) as any;
+
+    expect(result.connected).toBe(true);
+    expect(result.truncated).toBe(true);
+    expect(String(result.title)).toContain('Notes');
+    expect(String(result.text)).toContain('secret plan');
+  });
+
+  it('passes {connected:false} through untouched', async () => {
+    authenticatedTrpcCall.mockResolvedValue({ data: { connected: false } });
+
+    const result = await notionGetPageTool.execute!(
+      { pageId: 'pg-1' },
+      { requestContext: makeRequestContext() } as never,
+    );
+
+    expect(result).toEqual({ connected: false });
+  });
+
+  it('throws when no auth token is present', async () => {
+    await expect(
+      notionGetPageTool.execute!(
+        { pageId: 'pg-1' },
         { requestContext: new Map() } as never,
       ),
     ).rejects.toThrow(/authentication token/i);

--- a/src/mastra/tools/notion-tools.ts
+++ b/src/mastra/tools/notion-tools.ts
@@ -228,51 +228,41 @@ function wrapPropertyValue(value: unknown, context: string): unknown {
 export const notionGetPageTool = createTool({
   id: "notion-get-page",
   description:
-    "Get a Notion page by ID, including its properties and full block content (auto-paginates)",
+    "Read a specific Notion page's title and text content by ID (often an id from notion-search or notion-query-database). The Notion credential is resolved server-side — you never see it. " +
+    "Returns `{connected, id, title, url, text, truncated}`. The page text may be **truncated** (~3k chars): when `truncated:true`, tell the user you only read the start and ask if they want a specific section, rather than assuming you have the whole page. " +
+    "If `{connected:false}`, the user hasn't connected Notion — tell them to connect it in Settings → Integrations. " +
+    "If the page isn't found, the internal integration may not have been SHARED with that page — tell the user to share it with the integration in Notion.",
   inputSchema: z.object({
     pageId: z.string().describe("Notion page ID (UUID or 32-char hex)"),
   }),
   execute: async (inputData, { requestContext }) => {
+    const authToken = requestContext?.get("authToken") as string | undefined;
+    const userId = requestContext?.get("userId") as string | undefined;
+    const sessionId = requestContext?.get("whatsappSession") as string | undefined;
+    const workspaceId = requestContext?.get("workspaceId") as string | undefined;
+
+    if (!authToken) throw new Error("No authentication token available");
+
     try {
-      const client = getClientFromRuntime(requestContext);
-      const { pageId } = inputData;
+      const { data } = await authenticatedTrpcCall(
+        "mastra.notionGetPage",
+        { pageId: inputData.pageId, workspaceId: workspaceId || undefined },
+        { authToken, sessionId, userId },
+      );
 
-      const [page, blocks] = await Promise.all([
-        client.pages.retrieve({ page_id: pageId }),
-        getAllBlocks(client, pageId),
-      ]);
-
-      const p = page as any;
-
-      // Wrap Notion content — pages are untrusted external content
-      const wrappedContent = blocks
-        .map((b: any) => ({
-          type: b.type,
-          text: extractBlockText(b),
-          hasChildren: b.has_children ?? false,
-        }))
-        .filter((b) => b.text)
-        .map((b) => ({
-          ...b,
-          text: prepareUntrustedContent(b.text!, "notion_page"),
-        }));
-
-      // Wrap title and property values — page metadata is also untrusted
-      const rawTitle = extractPageTitle(p.properties ?? {});
-      const rawProps = extractProperties(p.properties ?? {});
-      const wrappedProps: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(rawProps)) {
-        wrappedProps[key] = wrapPropertyValue(value, "notion_page");
+      // Wrap the page title + text — Notion page content is untrusted external
+      // content (content-injection posture, ADR-0020).
+      if (data && (data as any).connected) {
+        const d = data as any;
+        if (typeof d.title === "string") {
+          d.title = prepareUntrustedContent(d.title, "notion_page");
+        }
+        if (typeof d.text === "string") {
+          d.text = prepareUntrustedContent(d.text, "notion_page");
+        }
       }
 
-      return {
-        id: p.id,
-        url: p.url,
-        title: prepareUntrustedContent(rawTitle, "notion_page"),
-        properties: wrappedProps,
-        content: wrappedContent,
-        blockCount: blocks.length,
-      };
+      return data;
     } catch (err) {
       return { error: formatError(err) };
     }


### PR DESCRIPTION
Companion to exponential's glossy.wolf (#133) — Notion get-page read slice.

Rewrites `notionGetPageTool` to carry only the agent JWT and call `mastra.notionGetPage`, which resolves the credential **server-side** (ADR-0020) and returns lean, **truncated** page content: `{connected, id, title, url, text, truncated}`. Title + text wrapped as untrusted external content.

- Description tells Zoe the text may be truncated (~3k chars) and to ask for a specific section rather than assume she has the whole page; carries the connect / shared-pages coaching.
- `getClientFromRuntime` + now-dead block/property helpers remain for create/update; removed in the final write slice (alpha.trail).

Verified: `npx tsc` (0 errors), `vitest` (12/12).

**Merge alongside** the exponential PR — the tool 404s until `mastra.notionGetPage` is deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for Notion page retrieval covering authentication validation, error scenarios, and content processing.

* **Improvements**
  * Enhanced Notion page tool with improved content security measures and stricter authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->