### PR TITLE
refactor: keystone guard (scalars) + scalar coercion sweep

### DIFF
--- a/src/mastra/tools/action-items-tools.ts
+++ b/src/mastra/tools/action-items-tools.ts
@@ -2,6 +2,7 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
 import { asAppContext } from "../types/request-context.js";
+import { looseNumber } from "./zod-loose.js";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Action Items Tools
@@ -307,10 +308,7 @@ export const getActionItemsTool = createTool({
       .enum(["ACTIVE", "COMPLETED", "CANCELLED"])
       .optional()
       .describe("Filter by action status"),
-    limit: z
-      .number()
-      .min(1)
-      .max(100)
+    limit: looseNumber(z.number().min(1).max(100))
       .default(20)
       .describe("Max results to return"),
   }),

--- a/src/mastra/tools/document-tools.ts
+++ b/src/mastra/tools/document-tools.ts
@@ -2,6 +2,7 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
 import { asAppContext } from "../types/request-context.js";
+import { looseNumber } from "./zod-loose.js";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Document Tools
@@ -179,11 +180,8 @@ export const searchDocumentsTool = createTool({
     "Semantic search across documents in the current workspace's knowledge base. Returns relevant text chunks with similarity scores. Use this when the user asks to find a document by topic or content.",
   inputSchema: z.object({
     query: z.string().min(1).describe("Natural language search query"),
-    limit: z.number().min(1).max(50).default(10).describe("Max results"),
-    similarityThreshold: z
-      .number()
-      .min(0)
-      .max(1)
+    limit: looseNumber(z.number().min(1).max(50)).default(10).describe("Max results"),
+    similarityThreshold: looseNumber(z.number().min(0).max(1))
       .default(0.3)
       .describe("Minimum cosine similarity (0-1). Lower = broader matches."),
   }),
@@ -268,7 +266,7 @@ export const getDocumentsTool = createTool({
       .enum(["pending", "processing", "completed", "failed"])
       .optional()
       .describe("Filter by ingestion status"),
-    limit: z.number().min(1).max(100).default(20),
+    limit: looseNumber(z.number().min(1).max(100)).default(20),
   }),
   outputSchema: z.array(
     z.object({

--- a/src/mastra/tools/email-tools.ts
+++ b/src/mastra/tools/email-tools.ts
@@ -2,6 +2,7 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
 import { prepareUntrustedContent, auditWriteAction } from "../utils/content-safety.js";
+import { looseNumber, looseBoolean } from "./zod-loose.js";
 
 // ==================== Email Tools ====================
 // Per-user email access via the Exponential backend (IMAP/SMTP).
@@ -45,14 +46,13 @@ export const getRecentEmailsTool = createTool({
   description:
     "Get recent emails from the user's inbox. Returns summaries (no full body). Use get-email-by-id to read full content.",
   inputSchema: z.object({
-    maxResults: z
+    maxResults: looseNumber(z
       .number()
       .min(1)
-      .max(50)
+      .max(50))
       .default(10)
       .describe("Maximum number of emails to return (default 10)"),
-    unreadOnly: z
-      .boolean()
+    unreadOnly: looseBoolean()
       .default(false)
       .describe("Only return unread emails"),
     since: z
@@ -181,10 +181,10 @@ export const searchEmailsTool = createTool({
     query: z
       .string()
       .describe("Search query — matches against sender, subject, and body"),
-    maxResults: z
+    maxResults: looseNumber(z
       .number()
       .min(1)
-      .max(50)
+      .max(50))
       .default(10)
       .describe("Maximum number of results (default 10)"),
   }),
@@ -249,8 +249,7 @@ export const sendEmailTool = createTool({
       .string()
       .optional()
       .describe("References header (for threading)"),
-    userConfirmed: z
-      .boolean()
+    userConfirmed: looseBoolean()
       .describe("REQUIRED: Must be true. You MUST show the user the full email draft and receive explicit confirmation before setting this to true."),
   }),
   outputSchema: z.object({
@@ -300,8 +299,7 @@ export const replyToEmailTool = createTool({
   inputSchema: z.object({
     emailId: z.string().describe("The email ID (UID) to reply to"),
     body: z.string().describe("Reply body (plain text)"),
-    userConfirmed: z
-      .boolean()
+    userConfirmed: looseBoolean()
       .describe("REQUIRED: Must be true. You MUST show the user the full reply draft and receive explicit confirmation before setting this to true."),
   }),
   outputSchema: z.object({

--- a/src/mastra/tools/index.ts
+++ b/src/mastra/tools/index.ts
@@ -740,10 +740,10 @@ export const updateProjectStatusTool = createTool({
       .enum(["HIGH", "MEDIUM", "LOW", "NONE"])
       .optional()
       .describe("Project priority"),
-    progress: z
+    progress: looseNumber(z
       .number()
       .min(0)
-      .max(100)
+      .max(100))
       .optional()
       .describe("Progress percentage (0-100)"),
     reviewDate: z
@@ -1056,25 +1056,23 @@ export const getMeetingTranscriptionsTool = createTool({
       .string()
       .optional()
       .describe("Filter by meeting type (standup, planning, review, etc.)"),
-    limit: z
-      .number()
+    limit: looseNumber(z
+      .number())
       .optional()
       .default(5)
       .describe("Maximum number of transcriptions to return (default: 5)"),
-    includeTranscript: z
-      .boolean()
+    includeTranscript: looseBoolean()
       .optional()
       .default(true)
       .describe(
         "Whether to fetch the full transcript text. Set false for list-style queries (titles + dates only) — much faster. Default: true."
       ),
-    truncateTranscript: z
-      .boolean()
+    truncateTranscript: looseBoolean()
       .optional()
       .default(true)
       .describe("Truncate transcript to prevent context overflow (default: true)"),
-    maxTranscriptLength: z
-      .number()
+    maxTranscriptLength: looseNumber(z
+      .number())
       .optional()
       .default(2000)
       .describe("Max characters per transcript when truncating (default: 2000)"),
@@ -1180,8 +1178,8 @@ export const queryMeetingContextTool = createTool({
       })
       .optional()
       .describe("Date range to search within"),
-    topK: z
-      .number()
+    topK: looseNumber(z
+      .number())
       .optional()
       .default(5)
       .describe("Number of most relevant results to return"),
@@ -1625,9 +1623,9 @@ export const findAvailableTimeSlotsTool = createTool({
   description: "Find available time slots in the user's calendar. Useful for scheduling new events. Specify date and work hours, returns free slots.",
   inputSchema: z.object({
     date: z.string().describe("Date to check in YYYY-MM-DD format"),
-    startHour: z.number().min(0).max(23).default(9).describe("Start of work day (hour, 0-23)"),
-    endHour: z.number().min(0).max(23).default(17).describe("End of work day (hour, 0-23)"),
-    slotDurationMinutes: z.number().default(30).describe("Desired slot duration in minutes"),
+    startHour: looseNumber(z.number().min(0).max(23)).default(9).describe("Start of work day (hour, 0-23)"),
+    endHour: looseNumber(z.number().min(0).max(23)).default(17).describe("End of work day (hour, 0-23)"),
+    slotDurationMinutes: looseNumber(z.number()).default(30).describe("Desired slot duration in minutes"),
   }),
   outputSchema: z.object({
     availableSlots: z.array(z.object({
@@ -1733,8 +1731,7 @@ export const createCalendarEventTool = createTool({
       displayName: z.string().optional(),
     })).optional().describe("List of attendees"),
     provider: z.enum(['google', 'microsoft']).default('google').describe("Calendar provider to use"),
-    userConfirmed: z
-      .boolean()
+    userConfirmed: looseBoolean()
       .describe("REQUIRED: Must be true. You MUST show the user the event details and receive explicit confirmation before setting this to true."),
   }),
   outputSchema: z.object({
@@ -1887,8 +1884,8 @@ export const getWhatsAppContextTool = createTool({
     contactName: z
       .string()
       .describe("Name of the contact for context in logs"),
-    limit: z
-      .number()
+    limit: looseNumber(z
+      .number())
       .default(20)
       .describe("Number of recent messages to fetch (default: 20)"),
   }),
@@ -2049,7 +2046,7 @@ export const searchCrmContactsTool = createTool({
     search: z.string().optional().describe("Search by first or last name"),
     tags: z.array(z.string()).optional().describe("Filter by tags (e.g., ['investor', 'advisor'])"),
     organizationId: z.string().optional().describe("Filter by organization ID"),
-    limit: z.number().default(20).describe("Max results to return (default: 20)"),
+    limit: looseNumber(z.number()).default(20).describe("Max results to return (default: 20)"),
   }),
   outputSchema: z.object({
     contacts: z.array(z.object({
@@ -2111,7 +2108,7 @@ export const getCrmContactTool = createTool({
     "Get full details for a specific CRM contact including social handles, about, skills, and recent interactions. Use after searching to get complete info.",
   inputSchema: z.object({
     contactId: z.string().describe("The contact ID to look up"),
-    includeInteractions: z.boolean().default(true).describe("Include recent interactions (default: true)"),
+    includeInteractions: looseBoolean().default(true).describe("Include recent interactions (default: true)"),
   }),
   outputSchema: z.object({
     id: z.string(),
@@ -2327,7 +2324,7 @@ export const searchCrmOrganizationsTool = createTool({
   inputSchema: z.object({
     search: z.string().optional().describe("Search by organization name or description"),
     industry: z.string().optional().describe("Filter by industry"),
-    limit: z.number().default(20).describe("Max results (default: 20)"),
+    limit: looseNumber(z.number()).default(20).describe("Max results (default: 20)"),
   }),
   outputSchema: z.object({
     organizations: z.array(z.object({

--- a/src/mastra/tools/keystone-guard.test.ts
+++ b/src/mastra/tools/keystone-guard.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// ── Keystone guard ──────────────────────────────────────────────────────────
+//
+// Walks EVERY exported tool's `inputSchema` and fails the build on any
+// model-facing scalar that isn't wrapped in the tolerant `zod-loose` helpers.
+// This turns the "coerce to preserve intent" convention (ADR-0001) from tribal
+// knowledge into a mechanically-enforced invariant: the next unwrapped
+// `z.number()` / `z.boolean()` someone adds to a tool input fails CI.
+//
+// Scope grows one class at a time, in lock-step with the sweeps:
+//   • scalars  (z.number / z.boolean)  — this ticket (deep.rune)
+//   • enums    (z.enum)                — zippy.acorn
+//   • arrays   (z.array)               — wet.llama
+// The guard only enforces a class once that class has been swept, so CI is
+// never red. Output schemas are exempt — they are produced by our code, never
+// by the model.
+//
+// Introspection reaches into zod v3 `_def` internals (typeName, innerType,
+// schema, effect, shape, type, options). That is intentional and pinned to the
+// repo's zod version; if zod's internals change, this guard is the canary.
+
+vi.mock('../utils/authenticated-fetch.js', () => ({
+  authenticatedTrpcCall: vi.fn(),
+  authenticatedTrpcQuery: vi.fn(),
+}));
+
+// Auto-discover every tool module. Glob picks up `*-tools.ts`; index.ts holds
+// the remaining tools (and re-exports many of the others — deduped by identity
+// below, so a tool is only checked once no matter how many modules export it).
+// `import.meta.glob` is a Vitest/Vite build-time macro and MUST appear as a
+// literal call for Vite to statically transform it (aliasing it breaks the
+// transform). tsc lacks the `vite/client` ambient types for it; CI runs vitest,
+// not tsc, so we silence the one type error here rather than pull in those
+// ambient types globally.
+// @ts-expect-error -- import.meta.glob is a Vite macro; no ambient type loaded
+const toolModules = import.meta.glob('./*-tools.ts', { eager: true }) as Record<
+  string,
+  Record<string, unknown>
+>;
+toolModules['./index.ts'] = (await import('./index.js')) as Record<string, unknown>;
+
+interface DiscoveredTool {
+  id: string;
+  exportName: string;
+  module: string;
+  inputSchema: any;
+}
+
+function discoverTools(): DiscoveredTool[] {
+  const seen = new Set<unknown>();
+  const tools: DiscoveredTool[] = [];
+  for (const [module, mod] of Object.entries(toolModules)) {
+    for (const [exportName, value] of Object.entries(mod)) {
+      const v = value as any;
+      const isTool =
+        v &&
+        typeof v === 'object' &&
+        typeof v.id === 'string' &&
+        v.inputSchema?._def?.typeName === 'ZodObject';
+      if (!isTool || seen.has(v)) continue;
+      seen.add(v);
+      tools.push({ id: v.id, exportName, module, inputSchema: v.inputSchema });
+    }
+  }
+  return tools;
+}
+
+// Strip the value-level wrappers that don't change the underlying type so the
+// walk can reason about the core node (and so `looseX().optional().default()`
+// is recognised as wrapped).
+function unwrap(schema: any): any {
+  let cur = schema;
+  while (cur?._def) {
+    const tn = cur._def.typeName;
+    if (tn === 'ZodOptional' || tn === 'ZodNullable' || tn === 'ZodDefault') {
+      cur = cur._def.innerType;
+      continue;
+    }
+    break;
+  }
+  return cur;
+}
+
+// A scalar is "loose-wrapped" iff it sits behind a `z.preprocess(...)`
+// (what looseNumber/looseBoolean produce) whose inner type is the scalar.
+function isLooseWrappedScalar(schema: any): boolean {
+  const u = unwrap(schema);
+  if (u?._def?.typeName === 'ZodEffects' && u._def.effect?.type === 'preprocess') {
+    const inner = unwrap(u._def.schema)?._def?.typeName;
+    return inner === 'ZodNumber' || inner === 'ZodBoolean';
+  }
+  return false;
+}
+
+// Recursively collect dotted paths to any bare (unwrapped) scalar input.
+function findBareScalars(schema: any, path: string, out: string[]): void {
+  if (isLooseWrappedScalar(schema)) return; // properly wrapped — stop here
+  const u = unwrap(schema);
+  if (!u?._def) return;
+  const tn = u._def.typeName;
+
+  if (tn === 'ZodNumber' || tn === 'ZodBoolean') {
+    out.push(`${path} (${tn})`);
+    return;
+  }
+  if (tn === 'ZodObject') {
+    const shape = typeof u._def.shape === 'function' ? u._def.shape() : u.shape;
+    for (const key of Object.keys(shape)) {
+      findBareScalars(shape[key], `${path}.${key}`, out);
+    }
+  } else if (tn === 'ZodArray') {
+    findBareScalars(u._def.type, `${path}[]`, out);
+  } else if (tn === 'ZodUnion') {
+    (u._def.options ?? []).forEach((opt: any, i: number) =>
+      findBareScalars(opt, `${path}|${i}`, out),
+    );
+  } else if (tn === 'ZodEffects') {
+    // refine/transform (non-preprocess) — descend into the wrapped schema.
+    findBareScalars(u._def.schema, path, out);
+  }
+}
+
+describe('keystone guard: model-facing scalar inputs must use zod-loose', () => {
+  const tools = discoverTools();
+
+  it('discovers the tool surface (sanity check the glob found tools)', () => {
+    expect(tools.length).toBeGreaterThan(40);
+  });
+
+  it('every model-facing z.number()/z.boolean() input is wrapped in looseNumber()/looseBoolean()', () => {
+    const violations: string[] = [];
+    for (const tool of tools) {
+      const bare: string[] = [];
+      findBareScalars(tool.inputSchema, tool.exportName, bare);
+      if (bare.length) {
+        violations.push(
+          `  ${tool.exportName} (${tool.id}) [${tool.module}]\n` +
+            bare.map((b) => `      ${b}`).join('\n'),
+        );
+      }
+    }
+    if (violations.length) {
+      throw new Error(
+        `Found ${violations.length} tool(s) with unwrapped model-facing scalar inputs.\n` +
+          `Wrap each in looseNumber()/looseBoolean() from ./zod-loose.js — see ADR-0001.\n` +
+          `Keep .min()/.max() INSIDE the wrapper, .optional()/.default()/.describe() outside:\n` +
+          `  limit: looseNumber(z.number().min(1).max(100)).optional().default(25).describe(...)\n\n` +
+          violations.join('\n'),
+      );
+    }
+  });
+});

--- a/src/mastra/tools/meeting-context-tools.ts
+++ b/src/mastra/tools/meeting-context-tools.ts
@@ -2,6 +2,7 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
 import { asAppContext } from "../types/request-context.js";
+import { looseNumber } from "./zod-loose.js";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Meeting Context Tools
@@ -119,7 +120,7 @@ export const searchContextTool = createTool({
     "Search the meeting knowledge base using semantic similarity. Returns relevant transcript sections with meeting metadata, speaker info, and timestamps. Use this to find historical context about topics, decisions, or discussions.",
   inputSchema: z.object({
     query: z.string().describe("Natural language search query"),
-    limit: z.number().min(1).max(50).default(10),
+    limit: looseNumber(z.number().min(1).max(50)).default(10),
     participantEmail: z
       .string()
       .email()
@@ -227,7 +228,7 @@ export const getParticipantHistoryTool = createTool({
     "Get meeting history and profile for a specific participant by email. Returns their workspace membership status, total meeting count, and a list of recent meetings they joined (with titles, dates, host flag, and summary).",
   inputSchema: z.object({
     email: z.string().email().describe("Participant email address"),
-    limit: z.number().min(1).max(50).default(10),
+    limit: looseNumber(z.number().min(1).max(50)).default(10),
   }),
   outputSchema: z.object({
     profile: z.object({
@@ -357,22 +358,13 @@ export const findRelatedMeetingsTool = createTool({
       .describe(
         "Attendee emails for the upcoming meeting; used for participant-overlap scoring",
       ),
-    matchThreshold: z
-      .number()
-      .min(0)
-      .max(1)
+    matchThreshold: looseNumber(z.number().min(0).max(1))
       .default(0.5)
       .describe("Minimum score (0-1) required to include a match"),
-    lookbackDays: z
-      .number()
-      .min(1)
-      .max(365)
+    lookbackDays: looseNumber(z.number().min(1).max(365))
       .default(90)
       .describe("How many days back to search for related meetings"),
-    limit: z
-      .number()
-      .min(1)
-      .max(50)
+    limit: looseNumber(z.number().min(1).max(50))
       .default(10)
       .describe("Maximum number of results per bucket"),
   }),

--- a/src/mastra/tools/project-tools.ts
+++ b/src/mastra/tools/project-tools.ts
@@ -1,7 +1,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
-import { looseNumber } from "./zod-loose.js";
+import { looseBoolean, looseNumber } from "./zod-loose.js";
 
 // ==================== Project & Action Management Tools ====================
 // Tools for creating projects and updating actions (including moving between projects).
@@ -136,7 +136,7 @@ export const deleteProjectTool = createTool({
     "Permanently delete a project. This action cannot be undone — all project data will be lost. Always confirm with the user before deleting. Ask the user to confirm by name before proceeding.",
   inputSchema: z.object({
     projectId: z.string().describe("The ID of the project to delete"),
-    confirmDeletion: z.boolean().describe("Must be explicitly true to proceed — confirm with the user before setting this"),
+    confirmDeletion: looseBoolean().describe("Must be explicitly true to proceed — confirm with the user before setting this"),
   }),
   outputSchema: z.object({
     success: z.boolean(),

--- a/src/mastra/tools/slack-tools.ts
+++ b/src/mastra/tools/slack-tools.ts
@@ -2,6 +2,7 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { WebClient } from "@slack/web-api";
 import { prepareUntrustedContent } from "../utils/content-safety.js";
+import { looseNumber, looseBoolean } from "./zod-loose.js";
 
 // Bot token client (xoxb-*)
 const slackBotClient = new WebClient(process.env.SLACK_BOT_TOKEN);
@@ -148,27 +149,27 @@ async function fetchAllSlackChannels(
 // Block Kit schemas
 const slackBlockElementSchema = z.object({
   type: z.string(),
-  text: z.object({ type: z.string(), text: z.string(), emoji: z.boolean().optional(), verbatim: z.boolean().optional() }).optional(),
+  text: z.object({ type: z.string(), text: z.string(), emoji: looseBoolean().optional(), verbatim: looseBoolean().optional() }).optional(),
   value: z.string().optional(),
   url: z.string().optional(),
   action_id: z.string().optional(),
   style: z.string().optional(),
   confirm: z.any().optional(),
-  placeholder: z.object({ type: z.string(), text: z.string(), emoji: z.boolean().optional() }).optional(),
+  placeholder: z.object({ type: z.string(), text: z.string(), emoji: looseBoolean().optional() }).optional(),
   initial_value: z.string().optional(),
-  options: z.array(z.object({ text: z.object({ type: z.string(), text: z.string(), emoji: z.boolean().optional() }), value: z.string() })).optional(),
+  options: z.array(z.object({ text: z.object({ type: z.string(), text: z.string(), emoji: looseBoolean().optional() }), value: z.string() })).optional(),
 });
 
 const slackBlockSchema = z.object({
   type: z.string(),
-  text: z.object({ type: z.string(), text: z.string(), emoji: z.boolean().optional(), verbatim: z.boolean().optional() }).optional(),
+  text: z.object({ type: z.string(), text: z.string(), emoji: looseBoolean().optional(), verbatim: looseBoolean().optional() }).optional(),
   elements: z.array(slackBlockElementSchema).optional(),
   accessory: slackBlockElementSchema.optional(),
   block_id: z.string().optional(),
-  fields: z.array(z.object({ type: z.string(), text: z.string(), emoji: z.boolean().optional(), verbatim: z.boolean().optional() })).optional(),
+  fields: z.array(z.object({ type: z.string(), text: z.string(), emoji: looseBoolean().optional(), verbatim: looseBoolean().optional() })).optional(),
   image_url: z.string().optional(),
   alt_text: z.string().optional(),
-  title: z.object({ type: z.string(), text: z.string(), emoji: z.boolean().optional() }).optional(),
+  title: z.object({ type: z.string(), text: z.string(), emoji: looseBoolean().optional() }).optional(),
 });
 
 // ── Existing tools (moved from index.ts) ─────────────────────────────
@@ -270,8 +271,8 @@ export const listSlackChannelsTool = createTool({
     "List Slack channels the bot has access to. Shows channel name, topic, purpose, member count, and whether it is archived. Use this to discover available channels before reading their history.",
   inputSchema: z.object({
     types: z.string().default("public_channel,private_channel").describe("Comma-separated channel types: public_channel, private_channel, mpim, im"),
-    excludeArchived: z.boolean().default(true).describe("Exclude archived channels (default: true)"),
-    limit: z.number().min(1).max(1000).default(200).describe("Max channels to return (default: 200, max: 1000). Fetches all pages automatically."),
+    excludeArchived: looseBoolean().default(true).describe("Exclude archived channels (default: true)"),
+    limit: looseNumber(z.number().min(1).max(1000)).default(200).describe("Max channels to return (default: 200, max: 1000). Fetches all pages automatically."),
   }),
   outputSchema: z.object({
     channels: z.array(z.object({
@@ -309,7 +310,7 @@ export const getSlackChannelHistoryTool = createTool({
     "Read recent messages from a Slack channel. Returns messages in reverse chronological order (newest first). Use the channel ID from list-slack-channels. Messages include sender display name, text, permalink, and thread info.",
   inputSchema: z.object({
     channel: z.string().describe("Channel ID (e.g., C1234567890). Use list-slack-channels to find IDs."),
-    limit: z.number().min(1).max(100).default(25).describe("Number of messages to return (default: 25, max: 100)"),
+    limit: looseNumber(z.number().min(1).max(100)).default(25).describe("Number of messages to return (default: 25, max: 100)"),
     oldest: z.string().optional().describe("Only messages after this Unix timestamp (e.g., '1234567890.123456')"),
     latest: z.string().optional().describe("Only messages before this Unix timestamp"),
   }),
@@ -359,7 +360,7 @@ export const getSlackThreadRepliesTool = createTool({
   inputSchema: z.object({
     channel: z.string().describe("Channel ID where the thread exists"),
     threadTs: z.string().describe("Timestamp (ts) of the thread's parent message"),
-    limit: z.number().min(1).max(100).default(50).describe("Max replies to return (default: 50)"),
+    limit: looseNumber(z.number().min(1).max(100)).default(50).describe("Max replies to return (default: 50)"),
   }),
   outputSchema: z.object({
     messages: z.array(z.object({
@@ -405,7 +406,7 @@ export const searchSlackMessagesTool = createTool({
   inputSchema: z.object({
     query: z.string().describe("Search query — keywords to look for in messages"),
     channel: z.string().optional().describe("Limit search to a specific channel ID (optional)"),
-    limit: z.number().min(1).max(50).default(20).describe("Max results to return (default: 20)"),
+    limit: looseNumber(z.number().min(1).max(50)).default(20).describe("Max results to return (default: 20)"),
   }),
   outputSchema: z.object({
     results: z.array(z.object({
@@ -517,9 +518,9 @@ export const getSlackMentionsTool = createTool({
     "Find @mentions of the user across Slack channels. Returns messages where the user was directly mentioned (@user), and optionally @here/@channel mentions. Use this when the user asks about tags, mentions, or who's been pinging them.",
   inputSchema: z.object({
     since: sinceEnum.default("24h").describe("Time window to search (default: 24h)"),
-    includeGroupMentions: z.boolean().default(true).describe("Include @here and @channel mentions (default: true)"),
-    limit: z.number().min(1).max(50).default(25).describe("Max mentions to return (default: 25)"),
-    maxChannels: z.number().min(1).max(50).default(20).describe("Max channels to scan in bot-token mode (default: 20)"),
+    includeGroupMentions: looseBoolean().default(true).describe("Include @here and @channel mentions (default: true)"),
+    limit: looseNumber(z.number().min(1).max(50)).default(25).describe("Max mentions to return (default: 25)"),
+    maxChannels: looseNumber(z.number().min(1).max(50)).default(20).describe("Max channels to scan in bot-token mode (default: 20)"),
   }),
   outputSchema: z.object({
     mentions: z.array(z.object({
@@ -685,9 +686,9 @@ export const getSlackUnreadsTool = createTool({
     "Show channels with unread messages or recent activity. With a user token, shows actual unread counts. Without a user token, shows channels with recent activity since a given time window. Use this when the user asks what they missed, about unreads, or wants to catch up on Slack.",
   inputSchema: z.object({
     since: sinceEnum.default("24h").describe("Time window for recent activity mode (default: 24h)"),
-    includeMessages: z.boolean().default(false).describe("Include actual recent messages in the response (default: false, just counts)"),
-    messagesPerChannel: z.number().min(1).max(10).default(3).describe("Messages to show per channel when includeMessages is true (default: 3)"),
-    maxChannels: z.number().min(1).max(50).default(30).describe("Max channels to check (default: 30)"),
+    includeMessages: looseBoolean().default(false).describe("Include actual recent messages in the response (default: false, just counts)"),
+    messagesPerChannel: looseNumber(z.number().min(1).max(10)).default(3).describe("Messages to show per channel when includeMessages is true (default: 3)"),
+    maxChannels: looseNumber(z.number().min(1).max(50)).default(30).describe("Max channels to check (default: 30)"),
   }),
   outputSchema: z.object({
     channels: z.array(z.object({

--- a/src/mastra/tools/ticket-tools.ts
+++ b/src/mastra/tools/ticket-tools.ts
@@ -1,6 +1,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
+import { looseNumber } from "./zod-loose.js";
 
 // ==================== Product Pipeline Ticket Tools ====================
 // Tools for listing products and filing tickets into a product's pipeline
@@ -87,14 +88,14 @@ export const createTicketTool = createTool({
       ])
       .optional()
       .describe("Initial pipeline status (defaults to BACKLOG)"),
-    priority: z
+    priority: looseNumber(z
       .number()
       .int()
       .min(0)
-      .max(4)
+      .max(4))
       .optional()
       .describe("Priority 0-4 (0 = critical, 4 = backlog)"),
-    points: z.number().optional().describe("Optional estimate in points"),
+    points: looseNumber(z.number()).optional().describe("Optional estimate in points"),
     assigneeId: z
       .string()
       .optional()
@@ -170,15 +171,15 @@ export const bulkCreateTicketsTool = createTool({
             ])
             .optional()
             .describe("Pipeline status. Map e.g. 'In progress'→IN_PROGRESS, 'Committed'→COMMITTED (defaults to BACKLOG)"),
-          priority: z
+          priority: looseNumber(z
             .number()
             .int()
             .min(0)
-            .max(4)
+            .max(4))
             .optional()
             .describe("Priority 0-4. Map High→1, Medium→2, Low→3 (reserve 0 for critical)"),
-          points: z
-            .number()
+          points: looseNumber(z
+            .number())
             .optional()
             .describe("Estimate in points. Map T-shirt sizes XS/S/M/L/XL → 1/2/3/5/8"),
           cycleName: z

--- a/src/mastra/tools/tool-input-coercion.test.ts
+++ b/src/mastra/tools/tool-input-coercion.test.ts
@@ -28,8 +28,29 @@ const {
   createOkrObjectiveTool,
   linkObjectiveToParentTool,
 } = await import('./okr-tools.js');
-const { getAllProjectsTool } = await import('./index.js');
-const { bulkCreateWorkspaceStructureTool } = await import('./project-tools.js');
+const {
+  getAllProjectsTool,
+  getMeetingTranscriptionsTool,
+  findAvailableTimeSlotsTool,
+} = await import('./index.js');
+const { bulkCreateWorkspaceStructureTool, deleteProjectTool } = await import(
+  './project-tools.js'
+);
+const { sendEmailTool, replyToEmailTool, getRecentEmailsTool } = await import(
+  './email-tools.js'
+);
+const { createTicketTool } = await import('./ticket-tools.js');
+const { listSlackChannelsTool } = await import('./slack-tools.js');
+const { findRelatedMeetingsTool } = await import('./meeting-context-tools.js');
+const { createSetupTool } = await import('./tradescape-tools.js');
+const { listWhatsAppChatsTool } = await import('./whatsapp-tools.js');
+const { getActionItemsTool } = await import('./action-items-tools.js');
+const { searchDocumentsTool } = await import('./document-tools.js');
+
+// Parse a single input field's schema in isolation (avoids constructing a full
+// valid tool input). Each field on a ZodObject is an independent schema.
+const parseField = (tool: { inputSchema?: unknown }, field: string, value: unknown): unknown =>
+  ((tool.inputSchema as any).shape[field] as z.ZodTypeAny).parse(value);
 
 describe('tool input coercion — the model emits scalars as strings', () => {
   it('getAllProjectsTool.includeAll: string "false" stays false (NOT the z.coerce.boolean footgun)', () => {
@@ -97,5 +118,67 @@ describe('goal hierarchy — parentGoalId coercion', () => {
     });
     expect(parsed.parentGoalId).toBe(19);
     expect((parsed.goals as Array<{ parentGoalId: number }>)[0]!.parentGoalId).toBe(20);
+  });
+});
+
+// ── Scalar coercion sweep (deep.rune) ───────────────────────────────────────
+// One representative swept field from every tool file, each asserting the three
+// behaviours the sweep guarantees: stringified value coerces, native value is
+// unchanged, and genuine garbage still throws (coercion is not blind
+// acceptance). The keystone-guard.test.ts enforces that the *rest* of the
+// scalar fields are wrapped; these rows pin the runtime behaviour.
+
+describe('scalar sweep — number fields coerce, pass through, and reject garbage', () => {
+  // `from`/`to` is the coercion case (chosen in-range for each field's
+  // .min/.max); the native passthrough re-uses `to`.
+  const numberFields: Array<{ name: string; tool: unknown; field: string; from: string; to: number }> = [
+    { name: 'getActionItemsTool.limit', tool: getActionItemsTool, field: 'limit', from: '7', to: 7 },
+    { name: 'searchDocumentsTool.similarityThreshold', tool: searchDocumentsTool, field: 'similarityThreshold', from: '0.7', to: 0.7 },
+    { name: 'getRecentEmailsTool.maxResults', tool: getRecentEmailsTool, field: 'maxResults', from: '7', to: 7 },
+    { name: 'findRelatedMeetingsTool.matchThreshold', tool: findRelatedMeetingsTool, field: 'matchThreshold', from: '0.7', to: 0.7 },
+    { name: 'listSlackChannelsTool.limit', tool: listSlackChannelsTool, field: 'limit', from: '7', to: 7 },
+    { name: 'createTicketTool.points', tool: createTicketTool, field: 'points', from: '7', to: 7 },
+    { name: 'createSetupTool.entryPrice', tool: createSetupTool, field: 'entryPrice', from: '100.5', to: 100.5 },
+    { name: 'listWhatsAppChatsTool.limit', tool: listWhatsAppChatsTool, field: 'limit', from: '7', to: 7 },
+    { name: 'getMeetingTranscriptionsTool.maxTranscriptLength', tool: getMeetingTranscriptionsTool, field: 'maxTranscriptLength', from: '1500', to: 1500 },
+    { name: 'findAvailableTimeSlotsTool.startHour', tool: findAvailableTimeSlotsTool, field: 'startHour', from: '9', to: 9 },
+  ];
+
+  it.each(numberFields)('$name: "$from" → $to, native → $to, "banana" throws', ({ tool, field, from, to }) => {
+    const t = tool as { inputSchema?: unknown };
+    expect(parseField(t, field, from)).toBe(to); // stringified coerces
+    expect(parseField(t, field, to)).toBe(to); // native passes through
+    expect(() => parseField(t, field, 'banana')).toThrow(); // garbage rejected
+  });
+
+  it('createTicketTool.priority keeps its .min/.max INSIDE the wrapper (out-of-range still throws)', () => {
+    expect(parseField(createTicketTool, 'priority', '3')).toBe(3);
+    expect(() => parseField(createTicketTool, 'priority', '9')).toThrow(); // max(4) preserved
+    expect(() => parseField(createTicketTool, 'priority', 'banana')).toThrow();
+  });
+});
+
+describe('scalar sweep — boolean fields coerce contents (not the z.coerce footgun)', () => {
+  const booleanFields: Array<{ name: string; tool: unknown; field: string }> = [
+    { name: 'sendEmailTool.userConfirmed', tool: sendEmailTool, field: 'userConfirmed' },
+    { name: 'replyToEmailTool.userConfirmed', tool: replyToEmailTool, field: 'userConfirmed' },
+    { name: 'deleteProjectTool.confirmDeletion', tool: deleteProjectTool, field: 'confirmDeletion' },
+    { name: 'getRecentEmailsTool.unreadOnly', tool: getRecentEmailsTool, field: 'unreadOnly' },
+    { name: 'listSlackChannelsTool.excludeArchived', tool: listSlackChannelsTool, field: 'excludeArchived' },
+    { name: 'getMeetingTranscriptionsTool.includeTranscript', tool: getMeetingTranscriptionsTool, field: 'includeTranscript' },
+  ];
+
+  it.each(booleanFields)('$name: "false" → false (NOT inverted), "true" → true, native passes', ({ tool, field }) => {
+    const t = tool as { inputSchema?: unknown };
+    // z.coerce.boolean("false") === true would silently invert the gate — these
+    // confirmation gates make that the difference between sending and not.
+    expect(parseField(t, field, 'false')).toBe(false);
+    expect(parseField(t, field, 'true')).toBe(true);
+    expect(parseField(t, field, true)).toBe(true);
+    expect(parseField(t, field, false)).toBe(false);
+  });
+
+  it('a confirmation gate rejects genuine garbage rather than defaulting it', () => {
+    expect(() => parseField(sendEmailTool, 'userConfirmed', 'banana')).toThrow();
   });
 });

--- a/src/mastra/tools/tradescape-tools.ts
+++ b/src/mastra/tools/tradescape-tools.ts
@@ -1,6 +1,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { TradescapeClient } from "tradescape-sdk";
+import { looseNumber } from "./zod-loose.js";
 
 // ==================== Tradescape Trading Tools ====================
 // Tools for managing trading setups, alerts, and positions.
@@ -29,7 +30,7 @@ export const listSetupsTool = createTool({
       .enum(["active", "closed", "cancelled"])
       .optional()
       .describe("Filter by status"),
-    limit: z.number().optional().default(10).describe("Maximum number of setups to return"),
+    limit: looseNumber(z.number()).optional().default(10).describe("Maximum number of setups to return"),
   }),
   outputSchema: z.object({
     setups: z.array(
@@ -90,9 +91,9 @@ export const createSetupTool = createTool({
   inputSchema: z.object({
     pair: z.string().describe("Trading pair (e.g., BTC/USDT)"),
     direction: z.enum(["long", "short"]).describe("Trade direction"),
-    entryPrice: z.number().optional().describe("Entry price"),
-    takeProfitPrice: z.number().optional().describe("Take profit price"),
-    stopPrice: z.number().optional().describe("Stop loss price"),
+    entryPrice: looseNumber(z.number()).optional().describe("Entry price"),
+    takeProfitPrice: looseNumber(z.number()).optional().describe("Take profit price"),
+    stopPrice: looseNumber(z.number()).optional().describe("Stop loss price"),
     timeframe: z.string().optional().describe("Timeframe (e.g., 1h, 4h, 1d)"),
     notes: z.string().optional().describe("Additional notes"),
   }),
@@ -153,7 +154,7 @@ export const listAlertsTool = createTool({
       .optional()
       .describe("Filter by status"),
     pair: z.string().optional().describe("Filter by trading pair"),
-    limit: z.number().optional().default(10).describe("Maximum number of alerts to return"),
+    limit: looseNumber(z.number()).optional().default(10).describe("Maximum number of alerts to return"),
   }),
   outputSchema: z.object({
     alerts: z.array(
@@ -208,7 +209,7 @@ export const createAlertTool = createTool({
     "Create a new price alert in Tradescape. Use this when the user wants to be notified when a price reaches a certain level.",
   inputSchema: z.object({
     pair: z.string().describe("Trading pair (e.g., BTC/USDT)"),
-    threshold: z.number().describe("Price threshold to trigger the alert"),
+    threshold: looseNumber(z.number()).describe("Price threshold to trigger the alert"),
     direction: z.enum(["above", "below"]).describe("Trigger when price goes above or below threshold"),
     message: z.string().optional().describe("Custom message for the alert"),
   }),

--- a/src/mastra/tools/whatsapp-tools.ts
+++ b/src/mastra/tools/whatsapp-tools.ts
@@ -1,5 +1,6 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
+import { looseNumber } from "./zod-loose.js";
 import { prepareUntrustedContent } from "../utils/content-safety.js";
 import { asAppContext } from "../types/request-context.js";
 /**
@@ -28,12 +29,12 @@ export const listWhatsAppChatsTool = createTool({
     "List all WhatsApp conversations with contact names, phone numbers, last message time, and message counts. " +
     "Use this to see who the user has been chatting with on WhatsApp.",
   inputSchema: z.object({
-    limit: z
-      .number()
+    limit: looseNumber(z
+      .number())
       .default(50)
       .describe("Max chats to return (default: 50)"),
-    offset: z
-      .number()
+    offset: looseNumber(z
+      .number())
       .default(0)
       .describe("Offset for pagination"),
   }),
@@ -82,8 +83,8 @@ export const getWhatsAppChatHistoryTool = createTool({
       .describe(
         "WhatsApp JID (e.g., '1234567890@s.whatsapp.net') or phone number in international format",
       ),
-    limit: z
-      .number()
+    limit: looseNumber(z
+      .number())
       .default(50)
       .describe("Max messages to return (default: 50)"),
     before: z
@@ -158,8 +159,8 @@ export const searchWhatsAppChatsTool = createTool({
       .string()
       .optional()
       .describe("Limit search to a specific chat (WhatsApp JID or phone number)"),
-    limit: z
-      .number()
+    limit: looseNumber(z
+      .number())
       .default(15)
       .describe("Max results to return (default: 15)"),
   }),

--- a/src/mastra/tools/zod-loose.ts
+++ b/src/mastra/tools/zod-loose.ts
@@ -42,8 +42,26 @@ const toNumber = (v: unknown): unknown => {
   return v; // fall through — inner z.number() rejects anything unexpected
 };
 
-export const looseBoolean = (inner: z.ZodBoolean = z.boolean()) =>
-  z.preprocess(toBoolean, inner);
+// The explicit return annotations matter. `z.preprocess` is typed against a
+// `(v: unknown) => unknown` preprocessor, so its inferred type carries
+// `unknown` for BOTH the input and output side. Mastra types a tool's
+// `execute(inputData)` from the schema's *input* type, so an unannotated
+// looseNumber/looseBoolean field surfaces in `inputData` as `unknown` / `{}`.
+// That's invisible until a coerced field is used as a real number/boolean
+// (arithmetic, comparisons, typed API params), at which point every such call
+// site fails to typecheck.
+//
+// We pin BOTH generics to the inner scalar type. The runtime is unchanged —
+// `.parse()` still accepts anything and coerces the stringified-scalar shapes
+// the model emits. The third generic (input) is a deliberate, harmless white
+// lie: by the time we read `inputData`, validation has already run and the
+// value IS a number/boolean, which is exactly what call sites need.
+export const looseBoolean = (
+  inner: z.ZodBoolean = z.boolean(),
+): z.ZodEffects<z.ZodBoolean, boolean, boolean> =>
+  z.preprocess(toBoolean, inner) as z.ZodEffects<z.ZodBoolean, boolean, boolean>;
 
-export const looseNumber = (inner: z.ZodNumber = z.number()) =>
-  z.preprocess(toNumber, inner);
+export const looseNumber = (
+  inner: z.ZodNumber = z.number(),
+): z.ZodEffects<z.ZodNumber, number, number> =>
+  z.preprocess(toNumber, inner) as z.ZodEffects<z.ZodNumber, number, number>;


### PR DESCRIPTION
## What

Part of **Robust agent tool inputs (ADR-0001)**. Two things that must ship together so CI never goes red:

1. **Keystone guard test** (`keystone-guard.test.ts`) — auto-discovers every exported tool and fails the build on any model-facing `z.number()`/`z.boolean()` input not wrapped in `looseNumber()`/`looseBoolean()`. Scalar scope only for now; it grows to enums (#3) and arrays (#4) as those classes are swept. Output schemas are exempt (not model-produced).

2. **Scalar coercion sweep** — wraps every model-facing scalar input (~40 fields across 10 tool files) in the tolerant helpers, **including required fields and confirmation gates** (`userConfirmed`, `confirmDeletion`). The shared Slack Block Kit schemas are wrapped once, covering both send/update tools. `zod-loose` imported in the files that lacked it.

### Also: fixed a latent typing bug in `zod-loose.ts`
`z.preprocess` infers `unknown` for both the input and output side, and Mastra types `execute(inputData)` from the schema's **input** type — so a coerced field surfaced as `unknown`/`{}` and failed to typecheck wherever used as a real number/boolean (Slack API params, hour comparisons, audit args). Pinned both generics to the inner scalar type; **runtime coercion is unchanged**.

## Verification

- `npm run test`: **7 files / 69 tests green** (guard + expanded coercion table).
- Coercion table covers one swept field per file: stringified coerces, native passes through, garbage throws; plus `.min/.max` stays inside the wrapper and a confirmation gate is never silently defaulted.
- `tsc --noEmit`: **no new errors** vs `main` (the only 4 errors are pre-existing in `calendar-tools.test.ts`).
- No `outputSchema` touched.

## Acceptance criteria

- [x] Guard enumerates all exported tools, fails on unwrapped model-facing `z.number()`/`z.boolean()`
- [x] Every model-facing scalar input wrapped (incl. required + confirmation-gate fields)
- [x] `zod-loose` imported in every tool file with model-facing scalars
- [x] `tool-input-coercion.test.ts` expanded with coerce / passthrough / reject-garbage rows
- [x] Full suite + guard green in CI; no output schema touched

---

Ships: deep.rune

Depends on #29 (CI) — already merged.