### PR TITLE
fix(agents): neutralize server-tool error results before replay (ADR-0002)

### DIFF
--- a/docs/adr/0002-robust-tool-outputs.md
+++ b/docs/adr/0002-robust-tool-outputs.md
@@ -1,0 +1,110 @@
+# Robust tool outputs: neutralize server-tool error results before replay
+
+## Context
+
+Anthropic server tools (`web_fetch`, `web_search`, code execution) return an
+*error* result variant — e.g. `web_fetch_tool_result_error` with
+`url_not_in_prior_context` when the model fetches a URL that isn't already in
+the conversation. web_fetch's [URL-validation rule](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-fetch-tool)
+makes this a *routine*, expected outcome for agent-initiated fetches, not a
+rare failure.
+
+The **live** turn already tolerates this: `@ai-sdk/anthropic`'s response parser
+accepts the error variant as part of a union, so the model receives the failure
+and narrates around it. The crash was observed on **replay**: on a subsequent
+turn the stored error block is re-serialized back to the API during request
+conversion, and a malformed/unrecognized provider-tool result value falls
+through to `validateTypes(webFetch_20250910OutputSchema)` (a success-only
+schema) and throws a Zod `Type validation failed` error. One failed fetch
+therefore **poisons the entire thread** — every later message dies during
+prompt construction, regardless of topic. The raw validation blob was being
+streamed verbatim into the chat UI.
+
+### Honest version/shape story (`@ai-sdk/anthropic` 3.0.37, verified)
+
+The exact reproduction depends on SDK version and on the precise stored shape.
+On the installed **3.0.37**, investigated directly (see the eval-replay test):
+
+- A *clean* `web_fetch_tool_result_error` value does **not** throw — the
+  converter has an explicit branch for it. True both for a hand-built
+  provider-executed prompt and through Mastra's own V2→model conversion (which
+  drops `providerExecuted` and re-emits the result as a plain `tool`-role
+  `tool_result`, stringified, with no schema validation).
+- The shape that **does** throw `Type validation failed` on 3.0.37 is an
+  *incomplete / malformed success* (`{ type: 'web_fetch_result', url }` with no
+  `retrievedAt`/`content`), which hits the success-only schema.
+
+So the originally observed production crash most plausibly came from an **older
+SDK** and/or a **non-clean provider-tool result shape**. The neutralizer's value
+is therefore version-independent: (i) **forward-compat** — it removes the
+provider-executed server-tool part entirely, so no future SDK version or new
+server tool can reintroduce a replay-side validation crash from this data; and
+(ii) it **covers malformed / unknown provider-tool result shapes** that do throw
+today. This is not a claim that 3.0.37 throws on the clean error block — it
+does not.
+
+This is the output-side sibling of [ADR-0001](./0001-robust-tool-inputs.md)
+(robust tool *inputs*): the same "the provider boundary will hand us
+plausible-but-unhandled shapes; absorb them at our layer" problem, on the way
+out instead of the way in.
+
+## Decision
+
+**Neutralize server-tool error results at our layer before they reach the
+provider's request conversion — for all server tools, not just web_fetch.**
+
+- A Mastra **input processor** scans conversation history and replaces any
+  server-tool `*_tool_result_error` block (and its `server_tool_use`) with a
+  short assistant **text note** recording the fact of failure, e.g.
+  `(Attempted web_fetch of <url> — failed: url_not_in_prior_context.)` (the
+  tool name and, when present, the URL and error code are included; nothing is
+  invented). This runs
+  proactively on every turn, is idempotent, de-poisons already-broken threads
+  on next read with no DB migration, and is independent of `@ai-sdk/anthropic`
+  version.
+- The decision is **version-independent by design**. The SDK bump
+  (3.0.37 → 3.0.84) is orthogonal hygiene shipped separately; the fix does not
+  depend on it.
+- Defense-in-depth: the chat-stream error branch never streams raw error text
+  to users — it emits a generic message and logs the masked error server-side.
+
+## Considered options
+
+- **Drop the tool_use + error result pair entirely** — *rejected.* Erases the
+  model's memory that it tried, so it may re-attempt the same dead URL.
+  Flattening to text preserves the fact-of-failure (ADR-0001's "preserve
+  intent, never invent it"), breaking retry loops.
+- **Coerce the stored block into the exact shape the SDK's error-handler
+  branch expects** — *rejected.* Couples us to `@ai-sdk/anthropic` internals;
+  a new tool version or refactor silently reintroduces the crash.
+- **Rely on the SDK upgrade** — *rejected as the primary fix.* The installed
+  3.0.37 already handles the *clean* error variant (verified — it does not throw
+  on it), yet the production crash still occurred — so the crash came from an
+  older SDK and/or a non-clean stored shape, and "just upgrade" neither explains
+  nor guarantees against it. New server tools or malformed shapes can
+  reintroduce the gap. Worth the bump for hygiene, not to depend on.
+- **Special-case web_fetch only** — *rejected.* `web_search` and code execution
+  produce the identical `*_tool_result_error` poison shape. ADR-0001 already
+  rejected per-tool exception lists in favour of one blanket rule.
+
+## Consequences
+
+- Applies to both agents (Zoe and the assistant), which both enable
+  `webSearch` + `webFetch`.
+- web_fetch's *misrouting* to app/Notion URLs (the misleading "I can access your
+  Payments database" behaviour) is a **separate** quality issue, deliberately
+  out of scope here — routing guidance already exists and was ignored, so it
+  needs a structural fix (e.g. `blocked_domains`), not more prompt.
+- Guarded by a processor unit test (web_fetch / web_search / code-exec error
+  shapes all flatten, zero error blocks remain) plus an eval-replay regression
+  that drives a **real Mastra `MessageList`** (re-applying the processor output
+  the way the runner does — `removeByIds` + `add`) and asserts that Mastra's own
+  V2→model conversion of the neutralized history carries no provider-executed
+  tool part and no `*_tool_result_error` (it does for the un-neutralized
+  history). The same suite pins the 3.0.37 version story (clean error block does
+  not throw; malformed success does).
+- **Detection is V2-format-coupled.** `isErroredServerToolPart` keys on the V2
+  `tool-invocation` part type. If Mastra emits a different message format (a
+  future V3) or the provider result lands as a different part type, the
+  neutralizer silently no-ops and the poison can return with no signal. Revisit
+  this predicate on any message-format bump.

--- a/src/mastra/agents/assistant-agent.ts
+++ b/src/mastra/agents/assistant-agent.ts
@@ -1,6 +1,7 @@
 import { anthropic } from '@ai-sdk/anthropic';
 import { Agent } from '@mastra/core/agent';
 import { memory } from '../memory/index.js';
+import { neutralizeServerToolErrorsProcessor } from '../processors/neutralize-server-tool-errors.js';
 import { withAnthropicPromptCache } from '../utils/anthropic-prompt-cache.js';
 import { EXPONENTIAL_CONTEXT } from './exponential-context.js';
 import { SECURITY_POLICY } from './security-policy.js';
@@ -405,6 +406,10 @@ export const assistantAgent = new Agent({
   memory,
   defaultOptions: assistantDefaultOptions,
   tools: assistantTools,
+  // Flatten Anthropic server-tool *_tool_result_error blocks to a text note
+  // before request conversion, so one failed web_fetch/web_search can't poison
+  // the whole thread on replay (ADR-0002).
+  inputProcessors: [neutralizeServerToolErrorsProcessor],
 });
 
 // Haiku 4.5 variant of Assistant. Identical instructions + tools + memory +
@@ -418,4 +423,5 @@ export const assistantAgentHaiku = new Agent({
   memory,
   defaultOptions: assistantDefaultOptions,
   tools: assistantTools,
+  inputProcessors: [neutralizeServerToolErrorsProcessor],
 });

--- a/src/mastra/agents/zoe-agent.ts
+++ b/src/mastra/agents/zoe-agent.ts
@@ -1,6 +1,7 @@
 import { anthropic } from '@ai-sdk/anthropic';
 import { Agent } from '@mastra/core/agent';
 import { memory } from '../memory/index.js';
+import { neutralizeServerToolErrorsProcessor } from '../processors/neutralize-server-tool-errors.js';
 import { withAnthropicPromptCache } from '../utils/anthropic-prompt-cache.js';
 import { EXPONENTIAL_CONTEXT } from './exponential-context.js';
 import { SECURITY_POLICY } from './security-policy.js';
@@ -603,6 +604,10 @@ export const zoeAgent = new Agent({
   memory,
   defaultOptions: zoeDefaultOptions,
   tools: zoeTools,
+  // Flatten Anthropic server-tool *_tool_result_error blocks to a text note
+  // before request conversion, so one failed web_fetch/web_search can't poison
+  // the whole thread on replay (ADR-0002).
+  inputProcessors: [neutralizeServerToolErrorsProcessor],
 });
 
 // Haiku 4.5 variant of Zoe. Identical SOUL prompt + tools + memory + cap so
@@ -620,6 +625,7 @@ export const zoeAgentHaiku = new Agent({
   memory,
   defaultOptions: zoeDefaultOptions,
   tools: zoeTools,
+  inputProcessors: [neutralizeServerToolErrorsProcessor],
 });
 
 // For reference: tool usage patterns

--- a/src/mastra/evals/neutralize-server-tool-errors-replay.test.ts
+++ b/src/mastra/evals/neutralize-server-tool-errors-replay.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vitest';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { MessageList } from '@mastra/core/agent/message-list';
+import type { MastraDBMessage } from '@mastra/core/agent/message-list';
+import { neutralizeServerToolErrors } from '../processors/neutralize-server-tool-errors.js';
+
+/**
+ * Eval-replay regression for ADR-0002 (sibling to ADR-0013's frozen-prefix
+ * harness): a stored web_fetch error block must NOT survive into the prompt
+ * the provider receives on the next turn.
+ *
+ * This is fully offline.
+ *
+ * ## What actually happens on @ai-sdk/anthropic 3.0.37 (investigated, not assumed)
+ *
+ * The headline claim "a stored `web_fetch_tool_result_error` block throws on
+ * replay" is NOT reproducible on the installed SDK (3.0.37), and we don't
+ * pretend it is:
+ *
+ *  - A *clean* `web_fetch_tool_result_error` value does NOT throw. The
+ *    converter has an explicit branch for it (index.js ~2193) that emits a
+ *    `web_fetch_tool_result` / `web_fetch_tool_result_error` block. True both
+ *    for a hand-built provider-executed prompt AND through Mastra's own
+ *    conversion.
+ *  - Mastra's V2→ModelMessage conversion drops `providerExecuted`, so the
+ *    stored result is re-emitted as a plain `tool`-role `tool-result`. That
+ *    path stringifies the value (no schema validation) — also no throw.
+ *  - The ONLY shape that throws `Type validation failed` on 3.0.37 is an
+ *    *incomplete / malformed success* (`{ type: 'web_fetch_result', url }`
+ *    with no `retrievedAt`/`content`), which falls through to
+ *    `validateTypes(webFetch_20250910OutputSchema)`. That is a malformed
+ *    provider-tool result shape, NOT the production error variant.
+ *
+ * So the observed production crash most plausibly came from an OLDER SDK
+ * and/or a non-clean provider-tool result shape. The neutralizer's value is
+ * therefore two-fold and version-independent:
+ *   (i)  forward-compat: it removes the provider-executed tool part entirely,
+ *        so no future SDK version / new server tool can reintroduce a
+ *        replay-side validation crash from this data; and
+ *   (ii) it covers the malformed / unknown provider-tool result shapes that DO
+ *        throw today (see the positive control below).
+ *
+ * The PRIMARY regression below proves de-poisoning through Mastra's REAL
+ * MessageList round-trip and its OWN V2→model conversion (the exact layer the
+ * agent feeds the provider), not a hand-rolled prompt: after neutralization the
+ * converted prompt carries NO provider-executed tool part and NO
+ * `*_tool_result_error`, whereas the un-neutralized history still does.
+ */
+
+// A stub fetch that returns a minimal valid Anthropic message response, so
+// reaching it means request CONVERSION succeeded.
+const stubAnthropicFetch: typeof fetch = async () =>
+  new Response(
+    JSON.stringify({
+      id: 'msg_stub',
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content: [{ type: 'text', text: 'ok' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+
+const model = createAnthropic({ apiKey: 'sk-test-offline', fetch: stubAnthropicFetch })(
+  'claude-sonnet-4-5',
+);
+const webFetchTool = [
+  {
+    type: 'provider-defined' as const,
+    id: 'anthropic.web_fetch_20250910',
+    name: 'web_fetch',
+    args: {},
+  },
+];
+
+/** The frozen thread: an assistant turn whose web_fetch errored, then a
+ * follow-up user message. This is what a poisoned thread looks like in V2. */
+function frozenHistoryWithStoredFetchError(): MastraDBMessage[] {
+  const invocation = {
+    toolCallId: 'tc_1',
+    toolName: 'web_fetch',
+    args: { url: 'https://example.com/blocked' },
+    state: 'result' as const,
+    result: {
+      type: 'web_fetch_tool_result_error',
+      errorCode: 'url_not_in_prior_context',
+    },
+  };
+  return [
+    {
+      id: 'm1',
+      role: 'assistant',
+      createdAt: new Date(),
+      content: {
+        format: 2,
+        parts: [
+          { type: 'text', text: 'Let me look that up.' },
+          { type: 'tool-invocation', toolInvocation: invocation } as never,
+        ],
+        toolInvocations: [invocation] as never,
+        content: 'Let me look that up.',
+      },
+    },
+    {
+      id: 'm2',
+      role: 'user',
+      createdAt: new Date(),
+      content: {
+        format: 2,
+        parts: [{ type: 'text', text: 'ok, what else can you tell me?' }],
+        content: 'ok, what else can you tell me?',
+      },
+    },
+  ];
+}
+
+/**
+ * Re-apply a processor's output to a MessageList EXACTLY the way Mastra's
+ * runner does in the `else` branch of `runInputProcessors`
+ * (`@mastra/core` chunk-BPT3YHUU.js ~line 1933): for each returned message,
+ * `removeByIds([id])` then `add(message, 'input')`. This is the load-bearing
+ * round-trip — it proves `MessageList.add()` faithfully ingests our rebuilt V2
+ * message and does NOT resurrect tool/error data from a field we didn't
+ * rebuild.
+ */
+function applyProcessorOutputLikeRunner(
+  list: MessageList,
+  returned: MastraDBMessage[],
+): void {
+  for (const message of returned) {
+    list.removeByIds([message.id]);
+    list.add(message, 'input');
+  }
+}
+
+/** True if any converted model message carries a provider-executed tool part
+ * (tool-call / tool-result) — i.e. the poison survived conversion. */
+function hasToolPart(modelMessages: { content: unknown }[]): boolean {
+  return modelMessages.some((m) =>
+    Array.isArray(m.content)
+      ? m.content.some(
+          (p: { type?: string }) =>
+            p.type === 'tool-call' || p.type === 'tool-result',
+        )
+      : false,
+  );
+}
+
+describe('ADR-0002 eval-replay regression: stored web_fetch error does not survive replay', () => {
+  it('PRIMARY: through Mastra\'s real MessageList + V2→model conversion, neutralization removes the provider-executed tool part and the *_tool_result_error', async () => {
+    // Baseline: the poisoned history, ingested by a REAL MessageList and run
+    // through Mastra's OWN conversion, still carries the tool part + the poison
+    // error shape. (On 3.0.37 this no longer THROWS — see the file docstring —
+    // but the provider-executed tool data is unmistakably present.)
+    const poisonedList = new MessageList();
+    poisonedList.add(frozenHistoryWithStoredFetchError(), 'memory');
+    const poisonedModel = poisonedList.get.all.aiV5.model();
+    const poisonedJson = JSON.stringify(poisonedModel);
+    expect(hasToolPart(poisonedModel)).toBe(true);
+    expect(poisonedJson).toContain('web_fetch_tool_result_error');
+
+    // Now de-poison: run the processor, then re-apply its output to a REAL
+    // MessageList the way the runner does (removeByIds + add), then use
+    // Mastra's OWN V2→model conversion to build the prompt.
+    const neutralizedList = new MessageList();
+    neutralizedList.add(frozenHistoryWithStoredFetchError(), 'memory');
+    const neutralized = neutralizeServerToolErrors(neutralizedList.get.all.db());
+    applyProcessorOutputLikeRunner(neutralizedList, neutralized);
+
+    const cleanModel = neutralizedList.get.all.aiV5.model();
+    const cleanJson = JSON.stringify(cleanModel);
+
+    // No provider-executed tool part survives, and the poison error shape is
+    // gone — replaced by the flattened text note.
+    expect(hasToolPart(cleanModel)).toBe(false);
+    expect(cleanJson).not.toContain('web_fetch_tool_result_error');
+    expect(cleanJson).toContain('Attempted web_fetch');
+
+    // And the SAME holds through the actual prompt the agent feeds the
+    // provider (`get.all.aiV5.llmPrompt()` — a LanguageModelV2Prompt).
+    const llmPrompt = await neutralizedList.get.all.aiV5.llmPrompt();
+    const promptJson = JSON.stringify(llmPrompt);
+    expect(promptJson).not.toContain('web_fetch_tool_result_error');
+    expect(
+      llmPrompt.some(
+        (m) =>
+          Array.isArray(m.content) &&
+          m.content.some(
+            (p: { type?: string }) =>
+              p.type === 'tool-call' || p.type === 'tool-result',
+          ),
+      ),
+    ).toBe(false);
+
+    // The neutralized prompt converts and reaches the (stubbed) provider
+    // without throwing — the thread is de-poisoned end to end.
+    const result = await model.doGenerate({
+      prompt: llmPrompt as never,
+      tools: webFetchTool as never,
+    });
+    expect(result).toBeDefined();
+  });
+
+  it('positive control: a MALFORMED provider-tool result (incomplete success) DOES throw on 3.0.37 — this is the shape class the neutralizer also covers, NOT the clean error variant', async () => {
+    // NOTE: this is deliberately an *incomplete success* shape, not the
+    // production `web_fetch_tool_result_error` variant. On 3.0.37 the clean
+    // error variant does NOT throw (see file docstring); only malformed /
+    // unknown provider-tool result shapes fall through to
+    // `validateTypes(webFetch_20250910OutputSchema)` and throw. The neutralizer
+    // removes ALL provider-executed server-tool results, so it covers this
+    // throwing shape as well as the (currently non-throwing but version-fragile)
+    // error variant.
+    const malformedPrompt = [
+      { role: 'user' as const, content: [{ type: 'text' as const, text: 'fetch it' }] },
+      {
+        role: 'assistant' as const,
+        content: [
+          {
+            type: 'tool-call' as const,
+            toolCallId: 'tc_1',
+            toolName: 'web_fetch',
+            input: { url: 'https://example.com/blocked' },
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-result' as const,
+            toolCallId: 'tc_1',
+            toolName: 'web_fetch',
+            output: {
+              type: 'json' as const,
+              // Incomplete success: missing retrievedAt/content -> schema fails.
+              value: { type: 'web_fetch_result', url: 'https://example.com/blocked' },
+            },
+            providerExecuted: true,
+          },
+        ],
+      },
+      { role: 'user' as const, content: [{ type: 'text' as const, text: 'now what?' }] },
+    ];
+
+    await expect(
+      model.doGenerate({ prompt: malformedPrompt as never, tools: webFetchTool as never }),
+    ).rejects.toThrow(/Type validation failed/);
+  });
+
+  it('control: a CLEAN web_fetch_tool_result_error block does NOT throw on 3.0.37 (documents the honest version story)', async () => {
+    // Pins the investigated fact: on 3.0.37 the converter handles the clean
+    // error variant. If a future SDK bump regresses this, this test flips and
+    // the failure is a clear signal to revisit ADR-0002's version narrative.
+    const cleanErrorPrompt = [
+      { role: 'user' as const, content: [{ type: 'text' as const, text: 'fetch it' }] },
+      {
+        role: 'assistant' as const,
+        content: [
+          {
+            type: 'tool-call' as const,
+            toolCallId: 'tc_1',
+            toolName: 'web_fetch',
+            input: { url: 'https://example.com/blocked' },
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-result' as const,
+            toolCallId: 'tc_1',
+            toolName: 'web_fetch',
+            output: {
+              type: 'json' as const,
+              value: {
+                type: 'web_fetch_tool_result_error',
+                errorCode: 'url_not_in_prior_context',
+              },
+            },
+            providerExecuted: true,
+          },
+        ],
+      },
+      { role: 'user' as const, content: [{ type: 'text' as const, text: 'now what?' }] },
+    ];
+
+    const result = await model.doGenerate({
+      prompt: cleanErrorPrompt as never,
+      tools: webFetchTool as never,
+    });
+    expect(result).toBeDefined();
+  });
+});

--- a/src/mastra/processors/neutralize-server-tool-errors.test.ts
+++ b/src/mastra/processors/neutralize-server-tool-errors.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect } from 'vitest';
+import type { MastraDBMessage } from '@mastra/core/agent/message-list';
+import {
+  neutralizeServerToolErrors,
+  NeutralizeServerToolErrorsProcessor,
+} from './neutralize-server-tool-errors.js';
+
+/**
+ * Tests for ADR-0002: server-tool error results must be flattened to a text
+ * note before the provider's request conversion, for ALL server tools, with
+ * surrounding content preserved and idempotent behaviour.
+ *
+ * The V2 message shapes here were captured empirically by feeding an AI SDK v6
+ * provider-executed tool result through Mastra's MessageList (see the module
+ * doc comment for the recorded shape).
+ */
+
+let idCounter = 0;
+const nextId = () => `m${++idCounter}`;
+
+/** Assistant message carrying one server-tool result part (errored or not). */
+function assistantWithToolResult(opts: {
+  toolName: string;
+  resultType: string;
+  errorCode?: string;
+  url?: string;
+  leadingText?: string;
+  successResult?: Record<string, unknown>;
+}): MastraDBMessage {
+  const invocation = {
+    toolCallId: 'tc_1',
+    toolName: opts.toolName,
+    args: opts.url ? { url: opts.url } : {},
+    state: 'result' as const,
+    result: opts.successResult ?? {
+      type: opts.resultType,
+      ...(opts.errorCode ? { errorCode: opts.errorCode } : {}),
+    },
+  };
+  const parts: MastraDBMessage['content']['parts'] = [];
+  if (opts.leadingText) parts.push({ type: 'text', text: opts.leadingText });
+  parts.push({ type: 'tool-invocation', toolInvocation: invocation } as never);
+  return {
+    id: nextId(),
+    role: 'assistant',
+    createdAt: new Date(),
+    content: {
+      format: 2,
+      parts,
+      // Mirrors that MessageList maintains alongside `parts`.
+      toolInvocations: [invocation] as never,
+      content: opts.leadingText ?? '',
+    },
+  };
+}
+
+const userMessage = (text: string): MastraDBMessage => ({
+  id: nextId(),
+  role: 'user',
+  createdAt: new Date(),
+  content: { format: 2, parts: [{ type: 'text', text }], content: text },
+});
+
+/** Count remaining `*_tool_result_error` blocks anywhere in the history. */
+function countErrorBlocks(messages: MastraDBMessage[]): number {
+  let n = 0;
+  for (const m of messages) {
+    for (const p of m.content?.parts ?? []) {
+      if (
+        p.type === 'tool-invocation' &&
+        typeof (p as { toolInvocation?: { result?: { type?: unknown } } })
+          .toolInvocation?.result?.type === 'string' &&
+        (
+          p as { toolInvocation: { result: { type: string } } }
+        ).toolInvocation.result.type.endsWith('_tool_result_error')
+      ) {
+        n++;
+      }
+    }
+    for (const inv of (m.content?.toolInvocations ?? []) as Array<{
+      result?: { type?: unknown };
+    }>) {
+      if (
+        typeof inv.result?.type === 'string' &&
+        inv.result.type.endsWith('_tool_result_error')
+      ) {
+        n++;
+      }
+    }
+  }
+  return n;
+}
+
+const firstTextPart = (m: MastraDBMessage): string | undefined => {
+  const p = m.content.parts.find((x) => x.type === 'text');
+  return p && p.type === 'text' ? p.text : undefined;
+};
+
+describe('neutralizeServerToolErrors', () => {
+  it('flattens a web_fetch error to a text note (URL + errorCode preserved)', () => {
+    const history = [
+      assistantWithToolResult({
+        toolName: 'web_fetch',
+        resultType: 'web_fetch_tool_result_error',
+        errorCode: 'url_not_in_prior_context',
+        url: 'https://example.com/x',
+        leadingText: 'Let me fetch that.',
+      }),
+      userMessage('thanks, now what?'),
+    ];
+
+    const out = neutralizeServerToolErrors(history);
+
+    expect(countErrorBlocks(out)).toBe(0);
+    const note = out[0].content.parts.find(
+      (p) => p.type === 'text' && p.text.includes('Attempted'),
+    );
+    expect(note && note.type === 'text' && note.text).toBe(
+      '(Attempted web_fetch of https://example.com/x — failed: url_not_in_prior_context.)',
+    );
+    // leading assistant text preserved
+    expect(firstTextPart(out[0])).toBe('Let me fetch that.');
+    // tool-invocation part is gone (replaced by text)
+    expect(out[0].content.parts.some((p) => p.type === 'tool-invocation')).toBe(
+      false,
+    );
+  });
+
+  it('flattens a web_search error', () => {
+    const out = neutralizeServerToolErrors([
+      assistantWithToolResult({
+        toolName: 'web_search',
+        resultType: 'web_search_tool_result_error',
+        errorCode: 'max_uses_exceeded',
+      }),
+    ]);
+    expect(countErrorBlocks(out)).toBe(0);
+    expect(firstTextPart(out[0])).toBe(
+      '(Attempted web_search — failed: max_uses_exceeded.)',
+    );
+  });
+
+  it('flattens a code-execution error', () => {
+    const out = neutralizeServerToolErrors([
+      assistantWithToolResult({
+        toolName: 'code_execution',
+        resultType: 'code_execution_tool_result_error',
+        errorCode: 'unavailable',
+      }),
+    ]);
+    expect(countErrorBlocks(out)).toBe(0);
+    expect(firstTextPart(out[0])).toBe(
+      '(Attempted code_execution — failed: unavailable.)',
+    );
+  });
+
+  it('handles snake_case error_code as well as camelCase errorCode', () => {
+    const msg = assistantWithToolResult({
+      toolName: 'web_fetch',
+      resultType: 'web_fetch_tool_result_error',
+      url: 'https://x.com',
+      successResult: {
+        type: 'web_fetch_tool_result_error',
+        error_code: 'unavailable',
+      },
+    });
+    const out = neutralizeServerToolErrors([msg]);
+    expect(firstTextPart(out[0])).toBe(
+      '(Attempted web_fetch of https://x.com — failed: unavailable.)',
+    );
+  });
+
+  it('preserves a SUCCESSFUL server-tool result untouched', () => {
+    const success = assistantWithToolResult({
+      toolName: 'web_fetch',
+      resultType: 'web_fetch_result',
+      url: 'https://x.com',
+      successResult: { type: 'web_fetch_result', url: 'https://x.com' },
+    });
+    const input = [success];
+    const out = neutralizeServerToolErrors(input);
+    // returned reference unchanged (nothing to neutralize)
+    expect(out).toBe(input);
+    expect(out[0].content.parts.some((p) => p.type === 'tool-invocation')).toBe(
+      true,
+    );
+    expect(countErrorBlocks(out)).toBe(0);
+  });
+
+  it('preserves unrelated user/assistant messages and their order', () => {
+    const history = [
+      userMessage('hi'),
+      assistantWithToolResult({
+        toolName: 'web_fetch',
+        resultType: 'web_fetch_tool_result_error',
+        errorCode: 'url_not_in_prior_context',
+        url: 'https://a.com',
+        leadingText: 'fetching',
+      }),
+      userMessage('and then'),
+    ];
+    const out = neutralizeServerToolErrors(history);
+    expect(out).toHaveLength(3);
+    expect(out[0]).toBe(history[0]); // untouched message kept by reference
+    expect(out[2]).toBe(history[2]);
+    expect(firstTextPart(out[0])).toBe('hi');
+    expect(firstTextPart(out[2])).toBe('and then');
+  });
+
+  it('strips the stale parallel toolInvocations[] mirror for errored results', () => {
+    const out = neutralizeServerToolErrors([
+      assistantWithToolResult({
+        toolName: 'web_fetch',
+        resultType: 'web_fetch_tool_result_error',
+        errorCode: 'url_not_in_prior_context',
+        url: 'https://x.com',
+      }),
+    ]);
+    expect(out[0].content.toolInvocations).toEqual([]);
+  });
+
+  it('returns a clean history unchanged (same reference)', () => {
+    const history = [userMessage('hi'), userMessage('there')];
+    expect(neutralizeServerToolErrors(history)).toBe(history);
+  });
+
+  it('returns an empty history unchanged', () => {
+    const empty: MastraDBMessage[] = [];
+    expect(neutralizeServerToolErrors(empty)).toBe(empty);
+  });
+
+  it('is idempotent: running twice equals running once', () => {
+    const history = [
+      assistantWithToolResult({
+        toolName: 'web_fetch',
+        resultType: 'web_fetch_tool_result_error',
+        errorCode: 'url_not_in_prior_context',
+        url: 'https://x.com',
+        leadingText: 'one',
+      }),
+      assistantWithToolResult({
+        toolName: 'web_search',
+        resultType: 'web_search_tool_result_error',
+        errorCode: 'max_uses_exceeded',
+      }),
+    ];
+    const once = neutralizeServerToolErrors(history);
+    const twice = neutralizeServerToolErrors(once);
+    expect(countErrorBlocks(twice)).toBe(0);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+    // second pass is a structural no-op: same reference returned
+    expect(neutralizeServerToolErrors(once)).toBe(once);
+  });
+
+  it('handles multiple errored parts within a single message', () => {
+    const inv = (toolName: string, type: string, code: string) => ({
+      toolCallId: `tc_${toolName}`,
+      toolName,
+      args: {},
+      state: 'result' as const,
+      result: { type, errorCode: code },
+    });
+    const msg: MastraDBMessage = {
+      id: nextId(),
+      role: 'assistant',
+      createdAt: new Date(),
+      content: {
+        format: 2,
+        parts: [
+          { type: 'text', text: 'trying things' },
+          {
+            type: 'tool-invocation',
+            toolInvocation: inv(
+              'web_fetch',
+              'web_fetch_tool_result_error',
+              'url_not_in_prior_context',
+            ),
+          } as never,
+          {
+            type: 'tool-invocation',
+            toolInvocation: inv(
+              'web_search',
+              'web_search_tool_result_error',
+              'max_uses_exceeded',
+            ),
+          } as never,
+        ],
+      },
+    };
+    const out = neutralizeServerToolErrors([msg]);
+    expect(countErrorBlocks(out)).toBe(0);
+    const noteTexts = out[0].content.parts
+      .filter((p) => p.type === 'text')
+      .map((p) => (p.type === 'text' ? p.text : ''));
+    expect(noteTexts).toContain('trying things');
+    expect(noteTexts.some((t) => t.includes('web_fetch'))).toBe(true);
+    expect(noteTexts.some((t) => t.includes('web_search'))).toBe(true);
+  });
+});
+
+describe('NeutralizeServerToolErrorsProcessor', () => {
+  it('processInput delegates to the pure function', () => {
+    const processor = new NeutralizeServerToolErrorsProcessor();
+    const history = [
+      assistantWithToolResult({
+        toolName: 'web_fetch',
+        resultType: 'web_fetch_tool_result_error',
+        errorCode: 'url_not_in_prior_context',
+        url: 'https://x.com',
+      }),
+    ];
+    // Only `messages` is read by the processor.
+    const out = processor.processInput({
+      messages: history,
+    } as never) as MastraDBMessage[];
+    expect(countErrorBlocks(out)).toBe(0);
+    expect(processor.id).toBe('neutralize-server-tool-errors');
+  });
+});

--- a/src/mastra/processors/neutralize-server-tool-errors.ts
+++ b/src/mastra/processors/neutralize-server-tool-errors.ts
@@ -1,0 +1,224 @@
+import type {
+  MastraDBMessage,
+  MastraMessagePart,
+} from '@mastra/core/agent/message-list';
+import type { Processor, ProcessInputArgs } from '@mastra/core/processors';
+
+/**
+ * Neutralize server-tool error results before replay — ADR-0002.
+ *
+ * Anthropic server tools (`web_fetch`, `web_search`, code execution) routinely
+ * return an *error* result variant — e.g. `web_fetch_tool_result_error` with
+ * `url_not_in_prior_context` when the model fetches a URL not already in the
+ * conversation. The live turn tolerates it (the response parser accepts the
+ * error as part of a union), but on every *subsequent* turn the stored error
+ * block is re-serialized back to the API and the request-conversion path
+ * validates it against a success-only schema (`web_fetch_result`) and throws a
+ * Zod `Type validation failed` error during prompt construction. One failed
+ * fetch therefore poisons the ENTIRE thread — every later message dies, on any
+ * topic.
+ *
+ * The fix neutralizes these error results at *our* layer, on Mastra's own V2
+ * message representation, before the provider's request conversion runs — so
+ * the throw never happens, for ALL server tools (no per-tool special-casing,
+ * per ADR-0001's rejection of exception lists). The errored
+ * `server_tool_use` + error result is flattened to a short assistant TEXT note
+ * recording the fact of failure, e.g.
+ * `(Attempted web_fetch of <url> — failed: url_not_in_prior_context.)`. This
+ * preserves the model's memory that it tried (breaking retry loops), keeps
+ * tool_use/result pairing valid, is independent of `@ai-sdk/anthropic`'s
+ * version, and is idempotent — running it twice equals running it once and a
+ * clean history passes through unchanged. It also de-poisons already-broken
+ * threads on next read with no DB migration.
+ *
+ * ## V2 message shape (determined empirically)
+ *
+ * A provider-executed server-tool result is stored on an assistant message as
+ * a `tool-invocation` part:
+ *
+ * ```jsonc
+ * {
+ *   "type": "tool-invocation",
+ *   "toolInvocation": {
+ *     "toolCallId": "tc_1",
+ *     "toolName": "web_fetch",          // or web_search / code_execution
+ *     "args": { "url": "https://…" },   // url present for web_fetch
+ *     "state": "result",
+ *     "result": {
+ *       "type": "web_fetch_tool_result_error",   // the poison: *_tool_result_error
+ *       "errorCode": "url_not_in_prior_context"
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * The V2 message also mirrors the same data into `content.toolInvocations[]`
+ * and a `content.content` string; both are rebuilt here so the neutralized
+ * message has no stale tool data for any downstream code path to resurrect.
+ */
+
+/** The discriminator on an errored server-tool result. */
+const ERROR_RESULT_TYPE_SUFFIX = '_tool_result_error';
+
+interface ServerToolErrorResult {
+  type: string;
+  errorCode?: unknown;
+  error_code?: unknown;
+}
+
+/** A V2 `tool-invocation` part carrying a resolved tool result. */
+interface ToolInvocationLike {
+  toolName?: unknown;
+  args?: unknown;
+  state?: unknown;
+  result?: unknown;
+}
+
+function isServerToolErrorResult(result: unknown): result is ServerToolErrorResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    typeof (result as { type?: unknown }).type === 'string' &&
+    (result as { type: string }).type.endsWith(ERROR_RESULT_TYPE_SUFFIX)
+  );
+}
+
+/**
+ * True when a part is a `tool-invocation` whose resolved result is a
+ * server-tool `*_tool_result_error` block — the shape that poisons replay.
+ *
+ * ⚠️ V2-format-coupled detection. This keys on `part.type === 'tool-invocation'`,
+ * which is Mastra's V2 message representation. If Mastra emits a different
+ * message format (e.g. a future V3) — or the provider result lands as a
+ * different part type — this predicate returns false, the neutralizer silently
+ * no-ops, and the poison can return with NO signal. This is an accepted
+ * trade-off today (V2 is what these agents store), but it is the first thing to
+ * revisit on any message-format bump. See ADR-0002 "Consequences".
+ */
+function isErroredServerToolPart(part: MastraMessagePart): boolean {
+  if (part.type !== 'tool-invocation') return false;
+  const invocation = (part as { toolInvocation?: ToolInvocationLike })
+    .toolInvocation;
+  return (
+    invocation?.state === 'result' && isServerToolErrorResult(invocation.result)
+  );
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Build the human-readable failure note for one errored server-tool part.
+ * Includes the URL (for web_fetch) and the error code when available, but
+ * never invents data it doesn't have.
+ */
+function buildFailureNote(invocation: ToolInvocationLike): string {
+  const toolName = asString(invocation.toolName) ?? 'server tool';
+  const url =
+    invocation.args &&
+    typeof invocation.args === 'object' &&
+    invocation.args !== null
+      ? asString((invocation.args as { url?: unknown }).url)
+      : undefined;
+  const result = invocation.result as ServerToolErrorResult;
+  const errorCode =
+    asString(result.errorCode) ?? asString(result.error_code) ?? 'error';
+
+  const target = url ? ` of ${url}` : '';
+  return `(Attempted ${toolName}${target} — failed: ${errorCode}.)`;
+}
+
+/** Concatenate the text of all `text` parts into the V2 `content` mirror. */
+function joinTextParts(parts: MastraMessagePart[]): string {
+  return parts
+    .filter((p): p is MastraMessagePart & { text: string } => p.type === 'text')
+    .map((p) => p.text)
+    .join('\n\n');
+}
+
+/**
+ * Pure core (ADR-0002): message-collection in, message-collection out. No I/O,
+ * no SDK/agent coupling. Replaces every server-tool `*_tool_result_error`
+ * block with a short assistant text note; leaves every other message and part
+ * — assistant text, SUCCESSFUL tool results, unrelated messages — untouched.
+ * Idempotent: a history with no error blocks is returned unchanged
+ * (referentially, the same array), and re-running on neutralized output is a
+ * no-op.
+ */
+export function neutralizeServerToolErrors(
+  messages: MastraDBMessage[],
+): MastraDBMessage[] {
+  let mutatedAny = false;
+
+  const result = messages.map((message) => {
+    const parts = message.content?.parts;
+    if (!Array.isArray(parts) || !parts.some(isErroredServerToolPart)) {
+      return message;
+    }
+
+    mutatedAny = true;
+
+    const newParts: MastraMessagePart[] = parts.map((part) => {
+      if (!isErroredServerToolPart(part)) return part;
+      const invocation = (part as { toolInvocation: ToolInvocationLike })
+        .toolInvocation;
+      const note: MastraMessagePart = {
+        type: 'text',
+        text: buildFailureNote(invocation),
+      };
+      return note;
+    });
+
+    // Rebuild the V2 message so no stale tool data survives in the parallel
+    // `toolInvocations[]` array or the `content` string mirror — both are
+    // derived from the now-flattened parts.
+    const oldToolInvocations = message.content.toolInvocations;
+    const keptToolInvocations = Array.isArray(oldToolInvocations)
+      ? oldToolInvocations.filter(
+          (inv) => !isServerToolErrorResult((inv as ToolInvocationLike).result),
+        )
+      : oldToolInvocations;
+
+    return {
+      ...message,
+      content: {
+        ...message.content,
+        parts: newParts,
+        ...(keptToolInvocations !== undefined
+          ? { toolInvocations: keptToolInvocations }
+          : {}),
+        ...(message.content.content !== undefined
+          ? { content: joinTextParts(newParts) }
+          : {}),
+      },
+    };
+  });
+
+  // Idempotency / clean-history fast path: return the original array reference
+  // when nothing changed.
+  return mutatedAny ? result : messages;
+}
+
+/**
+ * Thin Mastra input-processor wrapper around {@link neutralizeServerToolErrors}.
+ * Runs on every turn, before the provider's request conversion, on the V2
+ * message history. Wired onto both Zoe and the assistant agent (and their
+ * Haiku variants), which both enable `webSearch` + `webFetch`.
+ */
+export class NeutralizeServerToolErrorsProcessor
+  implements Processor<'neutralize-server-tool-errors'>
+{
+  readonly id = 'neutralize-server-tool-errors' as const;
+  readonly name = 'Neutralize Server-Tool Errors';
+  readonly description =
+    'Flattens Anthropic server-tool *_tool_result_error blocks to a text note before request conversion (ADR-0002).';
+
+  processInput({ messages }: ProcessInputArgs): MastraDBMessage[] {
+    return neutralizeServerToolErrors(messages);
+  }
+}
+
+/** Singleton instance for wiring into agent `inputProcessors`. */
+export const neutralizeServerToolErrorsProcessor =
+  new NeutralizeServerToolErrorsProcessor();


### PR DESCRIPTION
Implements Exponential ticket **micro.helm** (feature: Server-tool error resilience; spec: gold.puffin #149).

## Problem
A failed Anthropic server tool (web_fetch / web_search / code-exec) stored a `*_tool_result_error` block in history. On the *next* turn, replaying that history crashed request construction in `@ai-sdk/anthropic` (success-only schema), poisoning the whole thread. The live turn was already non-fatal; only replay crashed.

## Fix
A pure `neutralizeServerToolErrors` function flattens any stored server-tool error block (and its tool call) into a short assistant text note, wrapped in a Mastra input processor wired onto both agents (Zoe + assistant, incl. Haiku variants). Runs every turn, idempotent, de-poisons existing threads on next read, no DB migration, version-independent.

General scope (web_fetch + web_search + code-exec, no per-tool special-casing) per ADR-0002 — the output-side sibling of ADR-0001.

## Tests
- Unit: all three error shapes flatten; zero error blocks remain; surrounding content preserved; clean histories unchanged; idempotent.
- Replay regression (offline): a positive control reproduces the real `Type validation failed` crash, and asserts the neutralized history converts cleanly.