### PR TITLE
refactor: enum normalization — normalize-or-fail-loud, ban .catch

### DIFF
--- a/src/mastra/tools/action-items-tools.ts
+++ b/src/mastra/tools/action-items-tools.ts
@@ -2,7 +2,7 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
 import { asAppContext } from "../types/request-context.js";
-import { looseNumber } from "./zod-loose.js";
+import { looseEnum, looseNumber } from "./zod-loose.js";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Action Items Tools
@@ -304,8 +304,7 @@ export const getActionItemsTool = createTool({
       .email()
       .optional()
       .describe("Filter to actions assigned to this email"),
-    status: z
-      .enum(["ACTIVE", "COMPLETED", "CANCELLED"])
+    status: looseEnum(["ACTIVE", "COMPLETED", "CANCELLED"])
       .optional()
       .describe("Filter by action status"),
     limit: looseNumber(z.number().min(1).max(100))
@@ -400,14 +399,12 @@ export const updateActionItemTool = createTool({
     "Update an action's status, priority, description, or due date. Translates one2b-style status (OPEN/IN_PROGRESS/COMPLETED/CANCELLED) to exponential's ACTIVE/COMPLETED/CANCELLED + kanbanStatus. If a completionNote is provided alongside a COMPLETED status, an ActionComment is added.",
   inputSchema: z.object({
     actionItemId: z.string().describe("The exponential Action ID to update"),
-    status: z
-      .enum(["OPEN", "IN_PROGRESS", "COMPLETED", "OVERDUE", "CANCELLED"])
+    status: looseEnum(["OPEN", "IN_PROGRESS", "COMPLETED", "OVERDUE", "CANCELLED"])
       .optional()
       .describe(
         "New status. OVERDUE is derived server-side and is ignored if passed here.",
       ),
-    priority: z
-      .enum(["HIGH", "MEDIUM", "LOW"])
+    priority: looseEnum(["HIGH", "MEDIUM", "LOW"])
       .optional()
       .describe("New priority — translated to exponential's priority scale."),
     description: z

--- a/src/mastra/tools/document-tools.ts
+++ b/src/mastra/tools/document-tools.ts
@@ -2,7 +2,7 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
 import { asAppContext } from "../types/request-context.js";
-import { looseNumber } from "./zod-loose.js";
+import { looseEnum, looseNumber } from "./zod-loose.js";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Document Tools
@@ -26,8 +26,7 @@ export const ingestDocumentTool = createTool({
   description:
     "Ingest a document into exponential's workspace knowledge base from base64 binary, a URL, or raw text. Stores the original (when applicable), extracts text, chunks it, and embeds it for semantic search. Use sourceType to tag where the document originated (upload, meeting, whatsapp, email, api).",
   inputSchema: z.object({
-    source: z
-      .enum(["base64", "url", "text"])
+    source: looseEnum(["base64", "url", "text"])
       .describe(
         "How the document content is being supplied. base64 = encoded file binary; url = remote URL to fetch; text = inline raw text",
       ),
@@ -262,8 +261,7 @@ export const getDocumentsTool = createTool({
       .describe(
         "Filter by source type (e.g. upload, meeting, whatsapp, email, api)",
       ),
-    ingestionStatus: z
-      .enum(["pending", "processing", "completed", "failed"])
+    ingestionStatus: looseEnum(["pending", "processing", "completed", "failed"])
       .optional()
       .describe("Filter by ingestion status"),
     limit: looseNumber(z.number().min(1).max(100)).default(20),

--- a/src/mastra/tools/index.ts
+++ b/src/mastra/tools/index.ts
@@ -9,7 +9,7 @@ import {
 } from "../utils/authenticated-fetch.js";
 import { prepareUntrustedContent, auditWriteAction } from "../utils/content-safety.js";
 import { asAppContext } from "../types/request-context.js";
-import { looseBoolean, looseNumber } from "./zod-loose.js";
+import { looseBoolean, looseNumber, looseEnum } from "./zod-loose.js";
 
 interface GeocodingResponse {
   results: {
@@ -530,8 +530,7 @@ export const getProjectActionsTool = createTool({
     "Get all actions for a specific project with detailed status and priority information",
   inputSchema: z.object({
     projectId: z.string().describe("The project ID to get actions for"),
-    status: z
-      .enum(["ACTIVE", "COMPLETED", "CANCELLED"])
+    status: looseEnum(["ACTIVE", "COMPLETED", "CANCELLED"])
       .optional()
       .describe("Filter by action status"),
   }),
@@ -594,8 +593,7 @@ export const createProjectActionTool = createTool({
       .string()
       .optional()
       .describe("Detailed description of the action"),
-    priority: z
-      .enum(["Quick", "Scheduled", "1st Priority", "2nd Priority", "3rd Priority", "4th Priority", "5th Priority", "Errand", "Remember", "Watch", "Someday Maybe"])
+    priority: looseEnum(["Quick", "Scheduled", "1st Priority", "2nd Priority", "3rd Priority", "4th Priority", "5th Priority", "Errand", "Remember", "Watch", "Someday Maybe"])
       .describe("Action priority. Use 'Quick' for small tasks, 'Scheduled' for time-bound items, '1st Priority' through '5th Priority' for ranked importance, 'Errand' for errands, 'Remember' for things to keep in mind, 'Watch' for items to monitor, 'Someday Maybe' for future ideas"),
     dueDate: z.string().optional().describe("Due date in ISO format"),
   }),
@@ -732,12 +730,10 @@ export const updateProjectStatusTool = createTool({
   description: "Update project status and progress information",
   inputSchema: z.object({
     projectId: z.string().describe("The project ID to update"),
-    status: z
-      .enum(["ACTIVE", "ON_HOLD", "COMPLETED", "CANCELLED"])
+    status: looseEnum(["ACTIVE", "ON_HOLD", "COMPLETED", "CANCELLED"])
       .optional()
       .describe("New project status"),
-    priority: z
-      .enum(["HIGH", "MEDIUM", "LOW", "NONE"])
+    priority: looseEnum(["HIGH", "MEDIUM", "LOW", "NONE"])
       .optional()
       .describe("Project priority"),
     progress: looseNumber(z
@@ -1247,8 +1243,7 @@ export const getMeetingInsightsTool = createTool({
     "Extract key insights from recent meetings and calls including decisions, action items, deadlines, and project evolution. Use this to summarize what was discussed in calls or meetings.",
   inputSchema: z.object({
     projectId: z.string().optional().describe("Focus on specific project"),
-    timeframe: z
-      .enum(["last_week", "last_month", "last_quarter", "custom"])
+    timeframe: looseEnum(["last_week", "last_month", "last_quarter", "custom"])
       .default("last_week")
       .describe("Time period for insights"),
     startDate: z
@@ -1417,8 +1412,7 @@ export const getCalendarEventsTool = createTool({
   description:
     "Get calendar events for today or upcoming days. Use this tool for any request about calendar, schedule, meetings today, upcoming meetings, what's on the calendar, or scheduled events. This retrieves actual calendar/scheduled events, NOT past meeting transcriptions.",
   inputSchema: z.object({
-    timeframe: z
-      .enum(["today", "upcoming", "custom"])
+    timeframe: looseEnum(["today", "upcoming", "custom"])
       .default("today")
       .describe(
         "'today' for today's events, 'upcoming' for next N days, 'custom' for specific date range"
@@ -1572,7 +1566,7 @@ export const getCalendarEventsInRangeTool = createTool({
   inputSchema: z.object({
     timeMin: z.string().describe("Start date/time in ISO 8601 format (e.g., '2024-02-12T00:00:00Z')"),
     timeMax: z.string().describe("End date/time in ISO 8601 format (e.g., '2024-02-12T23:59:59Z')"),
-    provider: z.enum(['google', 'microsoft']).optional().describe("Optional: filter to specific provider"),
+    provider: looseEnum(['google', 'microsoft']).optional().describe("Optional: filter to specific provider"),
   }),
   outputSchema: z.object({
     events: z.array(z.object({
@@ -1730,7 +1724,7 @@ export const createCalendarEventTool = createTool({
       email: z.string().email(),
       displayName: z.string().optional(),
     })).optional().describe("List of attendees"),
-    provider: z.enum(['google', 'microsoft']).default('google').describe("Calendar provider to use"),
+    provider: looseEnum(['google', 'microsoft']).default('google').describe("Calendar provider to use"),
     userConfirmed: looseBoolean()
       .describe("REQUIRED: Must be true. You MUST show the user the event details and receive explicit confirmation before setting this to true."),
   }),
@@ -2276,8 +2270,8 @@ export const addCrmInteractionTool = createTool({
     "Log an interaction with a CRM contact (email, call, meeting, note, etc.). This updates the contact's last interaction timestamp and creates an audit trail.",
   inputSchema: z.object({
     contactId: z.string().describe("The contact ID to log interaction for"),
-    type: z.enum(["EMAIL", "PHONE_CALL", "MEETING", "NOTE", "LINKEDIN", "TELEGRAM", "OTHER"]).describe("Type of interaction"),
-    direction: z.enum(["INBOUND", "OUTBOUND"]).describe("Direction: INBOUND (they reached out) or OUTBOUND (you reached out)"),
+    type: looseEnum(["EMAIL", "PHONE_CALL", "MEETING", "NOTE", "LINKEDIN", "TELEGRAM", "OTHER"]).describe("Type of interaction"),
+    direction: looseEnum(["INBOUND", "OUTBOUND"]).describe("Direction: INBOUND (they reached out) or OUTBOUND (you reached out)"),
     subject: z.string().optional().describe("Brief subject line for the interaction"),
     notes: z.string().optional().describe("Detailed notes about the interaction"),
   }),
@@ -2381,7 +2375,7 @@ export const createCrmOrganizationTool = createTool({
     description: z.string().optional().describe("Description of the organization"),
     websiteUrl: z.string().optional().describe("Website URL"),
     industry: z.string().optional().describe("Industry (e.g., 'Technology', 'Finance', 'Healthcare')"),
-    size: z.enum(["1-10", "11-50", "51-200", "201-500", "501-1000", "1000+"]).optional().describe("Company size range"),
+    size: looseEnum(["1-10", "11-50", "51-200", "201-500", "501-1000", "1000+"]).optional().describe("Company size range"),
   }),
   outputSchema: z.object({
     id: z.string(),

--- a/src/mastra/tools/keystone-guard.test.ts
+++ b/src/mastra/tools/keystone-guard.test.ts
@@ -82,70 +82,120 @@ function unwrap(schema: any): any {
   return cur;
 }
 
-// A scalar is "loose-wrapped" iff it sits behind a `z.preprocess(...)`
-// (what looseNumber/looseBoolean produce) whose inner type is the scalar.
-function isLooseWrappedScalar(schema: any): boolean {
+// A node is "loose-wrapped" iff it sits behind a `z.preprocess(...)` (what
+// looseNumber/looseBoolean/looseEnum produce) whose inner type is in the set.
+function isLooseWrapped(schema: any, innerTypes: string[]): boolean {
   const u = unwrap(schema);
   if (u?._def?.typeName === 'ZodEffects' && u._def.effect?.type === 'preprocess') {
-    const inner = unwrap(u._def.schema)?._def?.typeName;
-    return inner === 'ZodNumber' || inner === 'ZodBoolean';
+    return innerTypes.includes(unwrap(u._def.schema)?._def?.typeName);
   }
   return false;
 }
+const isLooseWrappedScalar = (s: any) => isLooseWrapped(s, ['ZodNumber', 'ZodBoolean']);
+const isLooseWrappedEnum = (s: any) => isLooseWrapped(s, ['ZodEnum']);
 
-// Recursively collect dotted paths to any bare (unwrapped) scalar input.
-function findBareScalars(schema: any, path: string, out: string[]): void {
-  if (isLooseWrappedScalar(schema)) return; // properly wrapped — stop here
+// Does the optional/default/nullable/catch wrapper chain over this field
+// contain a `.catch()` guarding a model-facing enum/scalar? `.catch(default)`
+// silently substitutes a wrong value (ADR-0001 bans it on write tools) — and
+// it works on bare OR loose-wrapped cores, so detect it on the chain directly.
+function hasCatchOverGuardedClass(schema: any): boolean {
+  let cur = schema;
+  let sawCatch = false;
+  while (cur?._def) {
+    const tn = cur._def.typeName;
+    if (tn === 'ZodCatch') {
+      sawCatch = true;
+      cur = cur._def.innerType;
+      continue;
+    }
+    if (tn === 'ZodOptional' || tn === 'ZodNullable' || tn === 'ZodDefault') {
+      cur = cur._def.innerType;
+      continue;
+    }
+    break;
+  }
+  if (!sawCatch) return false;
+  const core = cur?._def?.typeName;
+  if (core === 'ZodNumber' || core === 'ZodBoolean' || core === 'ZodEnum') return true;
+  // a loose-wrapped core (preprocess) also counts
+  return core === 'ZodEffects' && cur._def.effect?.type === 'preprocess';
+}
+
+interface Violation {
+  path: string;
+  reason: string;
+}
+
+// Recursively collect every model-facing input that breaks a swept convention:
+//   • bare z.number()/z.boolean()      (scalars — deep.rune)
+//   • bare z.enum()                    (enums   — zippy.acorn)
+//   • a `.catch()` over any of those   (banned  — zippy.acorn)
+// A direct `z.array(z.enum())` (array-of-enum) is deferred to wet.llama (#4),
+// so its element enum is NOT flagged here. Enums nested inside an object that
+// happens to live in an array (e.g. `tickets[].status`) ARE flagged — they are
+// ordinary enum fields. Output schemas are never walked (not model-produced).
+function findViolations(schema: any, path: string, out: Violation[]): void {
+  if (hasCatchOverGuardedClass(schema)) {
+    out.push({ path, reason: '.catch() is banned on model-facing enums/scalars — use looseEnum/looseNumber/looseBoolean (normalize-then-fail, never silent-default)' });
+    return;
+  }
+  if (isLooseWrappedScalar(schema) || isLooseWrappedEnum(schema)) return; // properly wrapped
   const u = unwrap(schema);
   if (!u?._def) return;
   const tn = u._def.typeName;
 
   if (tn === 'ZodNumber' || tn === 'ZodBoolean') {
-    out.push(`${path} (${tn})`);
+    out.push({ path, reason: `bare ${tn} — wrap in looseNumber()/looseBoolean()` });
+    return;
+  }
+  if (tn === 'ZodEnum') {
+    out.push({ path, reason: 'bare ZodEnum — wrap in looseEnum()' });
     return;
   }
   if (tn === 'ZodObject') {
     const shape = typeof u._def.shape === 'function' ? u._def.shape() : u.shape;
     for (const key of Object.keys(shape)) {
-      findBareScalars(shape[key], `${path}.${key}`, out);
+      findViolations(shape[key], `${path}.${key}`, out);
     }
   } else if (tn === 'ZodArray') {
-    findBareScalars(u._def.type, `${path}[]`, out);
+    // Direct array-of-enum is wet.llama's (#4) territory — skip its element.
+    if (unwrap(u._def.type)?._def?.typeName === 'ZodEnum') return;
+    findViolations(u._def.type, `${path}[]`, out);
   } else if (tn === 'ZodUnion') {
     (u._def.options ?? []).forEach((opt: any, i: number) =>
-      findBareScalars(opt, `${path}|${i}`, out),
+      findViolations(opt, `${path}|${i}`, out),
     );
   } else if (tn === 'ZodEffects') {
     // refine/transform (non-preprocess) — descend into the wrapped schema.
-    findBareScalars(u._def.schema, path, out);
+    findViolations(u._def.schema, path, out);
   }
 }
 
-describe('keystone guard: model-facing scalar inputs must use zod-loose', () => {
+describe('keystone guard: model-facing inputs must use the zod-loose helpers', () => {
   const tools = discoverTools();
 
   it('discovers the tool surface (sanity check the glob found tools)', () => {
     expect(tools.length).toBeGreaterThan(40);
   });
 
-  it('every model-facing z.number()/z.boolean() input is wrapped in looseNumber()/looseBoolean()', () => {
+  it('every model-facing scalar/enum input is wrapped (and no .catch() on them)', () => {
     const violations: string[] = [];
     for (const tool of tools) {
-      const bare: string[] = [];
-      findBareScalars(tool.inputSchema, tool.exportName, bare);
-      if (bare.length) {
+      const found: Violation[] = [];
+      findViolations(tool.inputSchema, tool.exportName, found);
+      if (found.length) {
         violations.push(
           `  ${tool.exportName} (${tool.id}) [${tool.module}]\n` +
-            bare.map((b) => `      ${b}`).join('\n'),
+            found.map((v) => `      ${v.path} — ${v.reason}`).join('\n'),
         );
       }
     }
     if (violations.length) {
       throw new Error(
-        `Found ${violations.length} tool(s) with unwrapped model-facing scalar inputs.\n` +
-          `Wrap each in looseNumber()/looseBoolean() from ./zod-loose.js — see ADR-0001.\n` +
-          `Keep .min()/.max() INSIDE the wrapper, .optional()/.default()/.describe() outside:\n` +
-          `  limit: looseNumber(z.number().min(1).max(100)).optional().default(25).describe(...)\n\n` +
+        `Found ${violations.length} tool(s) with model-facing inputs that bypass the ` +
+          `coercion helpers (ADR-0001 — coerce to preserve intent, never invent it).\n` +
+          `Scalars → looseNumber()/looseBoolean() (keep .min/.max inside the wrapper).\n` +
+          `Enums   → looseEnum([...]) (normalize-then-fail; do NOT use .catch(default)).\n\n` +
           violations.join('\n'),
       );
     }

--- a/src/mastra/tools/meeting-context-tools.ts
+++ b/src/mastra/tools/meeting-context-tools.ts
@@ -2,7 +2,7 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
 import { asAppContext } from "../types/request-context.js";
-import { looseNumber } from "./zod-loose.js";
+import { looseNumber, looseEnum } from "./zod-loose.js";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Meeting Context Tools
@@ -128,8 +128,7 @@ export const searchContextTool = createTool({
       .describe(
         "Filter results to chunks from meetings this email attended. Note: this is a 'transcript-attended' filter (passes if the participant attended the meeting), not a 'speaker-spoke' filter (chunks where they specifically spoke).",
       ),
-    sourceType: z
-      .enum(["transcription", "document", "resource"])
+    sourceType: looseEnum(["transcription", "document", "resource"])
       .optional()
       .describe("Restrict search to a specific source type"),
   }),

--- a/src/mastra/tools/notion-tools.ts
+++ b/src/mastra/tools/notion-tools.ts
@@ -8,6 +8,7 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { prepareUntrustedContent } from "../utils/content-safety.js";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
+import { looseEnum } from "./zod-loose.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -50,7 +51,7 @@ export const notionSearchTool = createTool({
     "Use the returned page/database `id` with notion-get-page or notion-query-database.",
   inputSchema: z.object({
     query: z.string().describe("Search query"),
-    filter: z.enum(["page", "database"]).optional().describe("Filter by object type"),
+    filter: looseEnum(["page", "database"]).optional().describe("Filter by object type"),
   }),
   execute: async (inputData, { requestContext }) => {
     const authToken = requestContext?.get("authToken") as string | undefined;
@@ -154,7 +155,7 @@ export const notionQueryDatabaseTool = createTool({
       .array(
         z.object({
           property: z.string(),
-          direction: z.enum(["ascending", "descending"]),
+          direction: looseEnum(["ascending", "descending"]),
         })
       )
       .optional()

--- a/src/mastra/tools/okr-tools.ts
+++ b/src/mastra/tools/okr-tools.ts
@@ -1,7 +1,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
-import { looseNumber } from "./zod-loose.js";
+import { looseEnum, looseNumber } from "./zod-loose.js";
 
 // ==================== OKR Tools ====================
 // CRUD operations for Objectives (Goals) and Key Results.
@@ -186,7 +186,7 @@ export const createOkrKeyResultTool = createTool({
     description: z.string().optional().describe("Additional detail"),
     targetValue: looseNumber().describe("The target value to achieve (e.g., 100 for 100%, 50 for 50 customers)"),
     startValue: looseNumber().optional().default(0).describe("Starting value (default: 0)"),
-    unit: z.enum(["percent", "count", "currency", "hours", "custom"]).optional().default("percent")
+    unit: looseEnum(["percent", "count", "currency", "hours", "custom"]).optional().default("percent")
       .describe("Unit of measurement"),
     unitLabel: z.string().optional().describe("Custom unit label (e.g., 'customers', 'deals') - used when unit is 'custom'"),
     period: z.string().describe("OKR period (e.g., 'Q1-2026')"),
@@ -237,9 +237,9 @@ export const updateOkrKeyResultTool = createTool({
     targetValue: looseNumber().optional().describe("Updated target value"),
     currentValue: looseNumber().optional().describe("Updated current value"),
     startValue: looseNumber().optional().describe("Updated start value"),
-    unit: z.enum(["percent", "count", "currency", "hours", "custom"]).optional(),
+    unit: looseEnum(["percent", "count", "currency", "hours", "custom"]).optional(),
     unitLabel: z.string().optional(),
-    status: z.enum(["not-started", "on-track", "at-risk", "off-track", "achieved"]).optional()
+    status: looseEnum(["not-started", "on-track", "at-risk", "off-track", "achieved"]).optional()
       .describe("Manual status override"),
     confidence: looseNumber(z.number().min(0).max(100)).optional().describe("Confidence level 0-100"),
   }),
@@ -437,7 +437,7 @@ export const addObjectiveUpdateTool = createTool({
   inputSchema: z.object({
     goalId: looseNumber().describe("The numeric ID of the Objective (goal) to update — from the page context. Tolerant of a stringified number because the model often emits it as text lifted from the prompt."),
     content: z.string().min(1).max(10000).describe("The update text (markdown). Draft this and get the user's explicit confirmation before calling the tool."),
-    health: z.enum(["on-track", "at-risk", "off-track"]).describe("The health this check-in sets — moves the status badge. Infer from the conversation; default to the Objective's current health when unclear. Show it in the draft and confirm before posting."),
+    health: looseEnum(["on-track", "at-risk", "off-track"]).describe("The health this check-in sets — moves the status badge. Infer from the conversation; default to the Objective's current health when unclear. Show it in the draft and confirm before posting."),
   }),
   outputSchema: z.object({
     id: z.string(),

--- a/src/mastra/tools/one2b-tools.ts
+++ b/src/mastra/tools/one2b-tools.ts
@@ -1,6 +1,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { one2bTrpcMutation, one2bTrpcQuery, serperSearch } from "../utils/one2b-api.js";
+import { looseEnum } from "./zod-loose.js";
 
 // ─── Track definitions ──────────────────────────────────────────────────────
 // Each track maps to a specific tRPC router on the One2b platform.
@@ -221,7 +222,7 @@ export const one2bGetTrackQuestionsTool = createTool({
     "Use this after determining which track the contact likely belongs to. " +
     "Questions map directly to fields in the One2b CRM.",
   inputSchema: z.object({
-    track: trackEnum.describe("The One2b community track to get questions for"),
+    track: looseEnum(ONE2B_TRACKS).describe("The One2b community track to get questions for"),
   }),
   outputSchema: z.object({
     track: trackEnum,
@@ -266,7 +267,7 @@ export const one2bCreateLeadTool = createTool({
     "Call this once you have collected enough qualifying data from the conversation. " +
     "All tRPC endpoints are public (no auth required) and will trigger DocuSign NDA automatically.",
   inputSchema: z.object({
-    track: trackEnum.describe("Which track to create the lead in"),
+    track: looseEnum(ONE2B_TRACKS).describe("Which track to create the lead in"),
     // Common fields across all tracks
     fullName: z.string().describe("Full name of the contact"),
     email: z.string().email().describe("Email address"),
@@ -500,7 +501,7 @@ export const one2bLookupLeadTool = createTool({
     "Call this early in the conversation to avoid creating duplicate records.",
   inputSchema: z.object({
     email: z.string().email().describe("Email address to look up"),
-    track: trackEnum.optional().describe("If you know their track, search that specific router. Otherwise searches community leads."),
+    track: looseEnum(ONE2B_TRACKS).optional().describe("If you know their track, search that specific router. Otherwise searches community leads."),
   }),
   outputSchema: z.object({
     found: z.boolean(),
@@ -585,9 +586,9 @@ export const one2bEscalateTool = createTool({
   inputSchema: z.object({
     contactName: z.string().describe("Name of the contact"),
     contactEmail: z.string().email().describe("Email of the contact"),
-    track: trackEnum.describe("The identified track"),
+    track: looseEnum(ONE2B_TRACKS).describe("The identified track"),
     reason: z.string().describe("Why escalation is needed"),
-    urgency: z.enum(['high', 'medium', 'low']).describe("How urgently a human should follow up"),
+    urgency: looseEnum(['high', 'medium', 'low']).describe("How urgently a human should follow up"),
     conversationSummary: z.string().describe("Summary of the conversation so far"),
     dataCollected: z.record(z.unknown()).optional().describe("Qualification data collected so far"),
   }),

--- a/src/mastra/tools/project-tools.ts
+++ b/src/mastra/tools/project-tools.ts
@@ -1,7 +1,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
-import { looseBoolean, looseNumber } from "./zod-loose.js";
+import { looseBoolean, looseEnum, looseNumber } from "./zod-loose.js";
 
 // ==================== Project & Action Management Tools ====================
 // Tools for creating projects and updating actions (including moving between projects).
@@ -14,12 +14,10 @@ export const createProjectTool = createTool({
   inputSchema: z.object({
     name: z.string().min(1).describe("The project name"),
     description: z.string().optional().describe("A brief description of the project's purpose"),
-    status: z
-      .enum(["ACTIVE", "ON_HOLD", "COMPLETED", "CANCELLED"])
+    status: looseEnum(["ACTIVE", "ON_HOLD", "COMPLETED", "CANCELLED"])
       .optional()
       .describe("Project status (defaults to ACTIVE)"),
-    priority: z
-      .enum(["HIGH", "MEDIUM", "LOW", "NONE"])
+    priority: looseEnum(["HIGH", "MEDIUM", "LOW", "NONE"])
       .optional()
       .describe("Project priority (defaults to MEDIUM)"),
   }),
@@ -75,16 +73,14 @@ export const updateActionTool = createTool({
     name: z.string().min(1).optional().describe("New name for the action"),
     description: z.string().nullable().optional().describe("New description (set null to clear)"),
     projectId: z.string().nullable().optional().describe("Move the action to this project ID, or null to unassign from any project"),
-    priority: z
-      .enum([
+    priority: looseEnum([
         "Quick", "Scheduled",
         "1st Priority", "2nd Priority", "3rd Priority", "4th Priority", "5th Priority",
         "Errand", "Remember", "Watch", "Someday Maybe",
       ])
       .optional()
       .describe("New priority level"),
-    status: z
-      .enum(["ACTIVE", "COMPLETED", "CANCELLED"])
+    status: looseEnum(["ACTIVE", "COMPLETED", "CANCELLED"])
       .optional()
       .describe("New status"),
     dueDate: z.string().nullable().optional().describe("New due date in ISO format, or null to clear"),
@@ -223,7 +219,7 @@ export const bulkCreateWorkspaceStructureTool = createTool({
       projects: z.array(z.object({
         name: z.string().describe("Project name"),
         description: z.string().optional().describe("Project description"),
-        priority: z.enum(["HIGH", "MEDIUM", "LOW", "NONE"]).optional().describe("Project priority (defaults to MEDIUM)"),
+        priority: looseEnum(["HIGH", "MEDIUM", "LOW", "NONE"]).optional().describe("Project priority (defaults to MEDIUM)"),
         actions: z.array(z.object({
           name: z.string().describe("Action/task name"),
         })).optional().describe("Actions to create under this project"),

--- a/src/mastra/tools/slack-tools.ts
+++ b/src/mastra/tools/slack-tools.ts
@@ -2,7 +2,7 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { WebClient } from "@slack/web-api";
 import { prepareUntrustedContent } from "../utils/content-safety.js";
-import { looseNumber, looseBoolean } from "./zod-loose.js";
+import { looseNumber, looseBoolean, looseEnum } from "./zod-loose.js";
 
 // Bot token client (xoxb-*)
 const slackBotClient = new WebClient(process.env.SLACK_BOT_TOKEN);
@@ -510,7 +510,7 @@ export const searchSlackMessagesTool = createTool({
 
 // ── Mentions & Unreads tools ────────────────────────────────────────
 
-const sinceEnum = z.enum(["1h", "4h", "12h", "24h", "3d", "7d"]);
+const sinceEnum = looseEnum(["1h", "4h", "12h", "24h", "3d", "7d"]);
 
 export const getSlackMentionsTool = createTool({
   id: "get-slack-mentions",

--- a/src/mastra/tools/ticket-tools.ts
+++ b/src/mastra/tools/ticket-tools.ts
@@ -1,7 +1,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
-import { looseNumber } from "./zod-loose.js";
+import { looseEnum, looseNumber } from "./zod-loose.js";
 
 // ==================== Product Pipeline Ticket Tools ====================
 // Tools for listing products and filing tickets into a product's pipeline
@@ -69,12 +69,10 @@ export const createTicketTool = createTool({
       .string()
       .optional()
       .describe("Optional longer description / details for the ticket"),
-    type: z
-      .enum(["BUG", "FEATURE", "CHORE", "IMPROVEMENT", "SPIKE", "RESEARCH"])
+    type: looseEnum(["BUG", "FEATURE", "CHORE", "IMPROVEMENT", "SPIKE", "RESEARCH"])
       .optional()
       .describe("Ticket type (defaults to FEATURE)"),
-    status: z
-      .enum([
+    status: looseEnum([
         "BACKLOG",
         "NEEDS_REFINEMENT",
         "READY_TO_PLAN",
@@ -152,12 +150,10 @@ export const bulkCreateTicketsTool = createTool({
         z.object({
           title: z.string().min(1).max(300).describe("Short, descriptive ticket title"),
           body: z.string().optional().describe("Optional details. Put unmappable columns (e.g. Area) here."),
-          type: z
-            .enum(["BUG", "FEATURE", "CHORE", "IMPROVEMENT", "SPIKE", "RESEARCH"])
+          type: looseEnum(["BUG", "FEATURE", "CHORE", "IMPROVEMENT", "SPIKE", "RESEARCH"])
             .optional()
             .describe("Ticket type (defaults to FEATURE)"),
-          status: z
-            .enum([
+          status: looseEnum([
               "BACKLOG",
               "NEEDS_REFINEMENT",
               "READY_TO_PLAN",

--- a/src/mastra/tools/tool-input-coercion.test.ts
+++ b/src/mastra/tools/tool-input-coercion.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { z } from 'zod';
+import { looseEnum, normalizeEnumValue } from './zod-loose.js';
 
 // Regression guard for the failure class documented in zod-loose.ts: the model
 // (Haiku especially) emits JSON-stringified scalars ("19", "false") instead of
@@ -27,11 +28,13 @@ const {
   checkInOkrKeyResultTool,
   createOkrObjectiveTool,
   linkObjectiveToParentTool,
+  addObjectiveUpdateTool,
 } = await import('./okr-tools.js');
 const {
   getAllProjectsTool,
   getMeetingTranscriptionsTool,
   findAvailableTimeSlotsTool,
+  createProjectActionTool,
 } = await import('./index.js');
 const { bulkCreateWorkspaceStructureTool, deleteProjectTool } = await import(
   './project-tools.js'
@@ -42,7 +45,7 @@ const { sendEmailTool, replyToEmailTool, getRecentEmailsTool } = await import(
 const { createTicketTool } = await import('./ticket-tools.js');
 const { listSlackChannelsTool } = await import('./slack-tools.js');
 const { findRelatedMeetingsTool } = await import('./meeting-context-tools.js');
-const { createSetupTool } = await import('./tradescape-tools.js');
+const { createSetupTool, syncTradesTool } = await import('./tradescape-tools.js');
 const { listWhatsAppChatsTool } = await import('./whatsapp-tools.js');
 const { getActionItemsTool } = await import('./action-items-tools.js');
 const { searchDocumentsTool } = await import('./document-tools.js');
@@ -180,5 +183,65 @@ describe('scalar sweep — boolean fields coerce contents (not the z.coerce foot
 
   it('a confirmation gate rejects genuine garbage rather than defaulting it', () => {
     expect(() => parseField(sendEmailTool, 'userConfirmed', 'banana')).toThrow();
+  });
+});
+
+// ── Enum normalization (zippy.acorn) ────────────────────────────────────────
+// The model emits near-miss enum members; looseEnum normalizes them to the
+// canonical member while an unmappable value still fails loud (the model then
+// retries against the Zod error). A near-miss must NEVER be silently defaulted
+// to a wrong value (.catch is banned) — that's the data-integrity bug ADR-0001
+// is about, and it matters most on write tools like ticket status.
+
+describe('enum normalization — near-miss coerces to canonical, garbage fails loud', () => {
+  it('createTicketTool.status: human phrasing → canonical UPPER_SNAKE', () => {
+    expect(parseField(createTicketTool, 'status', 'In Progress')).toBe('IN_PROGRESS');
+    expect(parseField(createTicketTool, 'status', 'in-progress')).toBe('IN_PROGRESS');
+    expect(parseField(createTicketTool, 'status', 'ready to plan')).toBe('READY_TO_PLAN');
+    expect(parseField(createTicketTool, 'status', 'DONE')).toBe('DONE'); // canonical passes
+    // Unmappable fails loud — NOT silently defaulted to BACKLOG (the bug ADR-0001 bans).
+    expect(() => parseField(createTicketTool, 'status', 'shipping')).toThrow();
+  });
+
+  it('createTicketTool.type: case/spacing-insensitive', () => {
+    expect(parseField(createTicketTool, 'type', 'bug')).toBe('BUG');
+    expect(parseField(createTicketTool, 'type', 'Feature')).toBe('FEATURE');
+    expect(() => parseField(createTicketTool, 'type', 'epic')).toThrow();
+  });
+
+  it('createProjectActionTool.priority: the 11-value human-cased enum maps to its own casing', () => {
+    expect(parseField(createProjectActionTool, 'priority', '1st priority')).toBe('1st Priority');
+    expect(parseField(createProjectActionTool, 'priority', 'SOMEDAY MAYBE')).toBe('Someday Maybe');
+    expect(parseField(createProjectActionTool, 'priority', 'Quick')).toBe('Quick'); // canonical
+    expect(() => parseField(createProjectActionTool, 'priority', 'urgent')).toThrow();
+  });
+
+  it('addObjectiveUpdateTool.health: hyphenated lowercase enum', () => {
+    expect(parseField(addObjectiveUpdateTool, 'health', 'On Track')).toBe('on-track');
+    expect(parseField(addObjectiveUpdateTool, 'health', 'off_track')).toBe('off-track');
+    expect(() => parseField(addObjectiveUpdateTool, 'health', 'great')).toThrow();
+  });
+
+  it('syncTradesTool.exchange: case-insensitive lowercase enum', () => {
+    expect(parseField(syncTradesTool, 'exchange', 'Binance')).toBe('binance');
+    expect(() => parseField(syncTradesTool, 'exchange', 'coinbase')).toThrow();
+  });
+});
+
+describe('looseEnum helper in isolation', () => {
+  it('normalizeEnumValue maps near-misses on a separator/case-insensitive key', () => {
+    const vals = ['IN_PROGRESS', 'READY_TO_PLAN'] as const;
+    expect(normalizeEnumValue(vals, 'in progress')).toBe('IN_PROGRESS');
+    expect(normalizeEnumValue(vals, 'Ready-To-Plan')).toBe('READY_TO_PLAN');
+    expect(normalizeEnumValue(vals, 'IN_PROGRESS')).toBe('IN_PROGRESS'); // canonical
+    expect(normalizeEnumValue(vals, 'nonsense')).toBe('nonsense'); // unmappable → unchanged
+    expect(normalizeEnumValue(vals, 42)).toBe(42); // non-strings pass through
+  });
+
+  it('looseEnum normalizes then validates (near-miss coerces, unmappable throws)', () => {
+    const schema = looseEnum(['low', 'high']);
+    expect(schema.parse('HIGH')).toBe('high');
+    expect(schema.parse('low')).toBe('low');
+    expect(() => schema.parse('medium')).toThrow();
   });
 });

--- a/src/mastra/tools/tradescape-tools.ts
+++ b/src/mastra/tools/tradescape-tools.ts
@@ -1,7 +1,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { TradescapeClient } from "tradescape-sdk";
-import { looseNumber } from "./zod-loose.js";
+import { looseNumber, looseEnum } from "./zod-loose.js";
 
 // ==================== Tradescape Trading Tools ====================
 // Tools for managing trading setups, alerts, and positions.
@@ -26,8 +26,7 @@ export const listSetupsTool = createTool({
   description:
     "List trading setups from Tradescape. Use this when the user asks about their trading setups, open positions, or trade ideas.",
   inputSchema: z.object({
-    status: z
-      .enum(["active", "closed", "cancelled"])
+    status: looseEnum(["active", "closed", "cancelled"])
       .optional()
       .describe("Filter by status"),
     limit: looseNumber(z.number()).optional().default(10).describe("Maximum number of setups to return"),
@@ -90,7 +89,7 @@ export const createSetupTool = createTool({
     "Create a new trading setup in Tradescape. Use this when the user wants to record a trade idea or setup.",
   inputSchema: z.object({
     pair: z.string().describe("Trading pair (e.g., BTC/USDT)"),
-    direction: z.enum(["long", "short"]).describe("Trade direction"),
+    direction: looseEnum(["long", "short"]).describe("Trade direction"),
     entryPrice: looseNumber(z.number()).optional().describe("Entry price"),
     takeProfitPrice: looseNumber(z.number()).optional().describe("Take profit price"),
     stopPrice: looseNumber(z.number()).optional().describe("Stop loss price"),
@@ -149,8 +148,7 @@ export const listAlertsTool = createTool({
   description:
     "List price alerts from Tradescape. Use this when the user asks about their alerts or price notifications.",
   inputSchema: z.object({
-    status: z
-      .enum(["pending", "triggered", "cancelled"])
+    status: looseEnum(["pending", "triggered", "cancelled"])
       .optional()
       .describe("Filter by status"),
     pair: z.string().optional().describe("Filter by trading pair"),
@@ -210,7 +208,7 @@ export const createAlertTool = createTool({
   inputSchema: z.object({
     pair: z.string().describe("Trading pair (e.g., BTC/USDT)"),
     threshold: looseNumber(z.number()).describe("Price threshold to trigger the alert"),
-    direction: z.enum(["above", "below"]).describe("Trigger when price goes above or below threshold"),
+    direction: looseEnum(["above", "below"]).describe("Trigger when price goes above or below threshold"),
     message: z.string().optional().describe("Custom message for the alert"),
   }),
   outputSchema: z.object({
@@ -341,7 +339,7 @@ export const syncTradesTool = createTool({
   description:
     "Sync trades from an exchange to Tradescape. Use this when the user wants to import their recent trades.",
   inputSchema: z.object({
-    exchange: z.enum(["binance", "kraken", "bybit", "hyperliquid"]).describe("Exchange to sync from"),
+    exchange: looseEnum(["binance", "kraken", "bybit", "hyperliquid"]).describe("Exchange to sync from"),
   }),
   outputSchema: z.object({
     count: z.number(),

--- a/src/mastra/tools/whatsapp-tools.ts
+++ b/src/mastra/tools/whatsapp-tools.ts
@@ -1,6 +1,6 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
-import { looseNumber } from "./zod-loose.js";
+import { looseNumber, looseEnum } from "./zod-loose.js";
 import { prepareUntrustedContent } from "../utils/content-safety.js";
 import { asAppContext } from "../types/request-context.js";
 /**
@@ -149,8 +149,7 @@ export const searchWhatsAppChatsTool = createTool({
     query: z
       .string()
       .describe("Search query — can be keywords or a natural language question"),
-    searchType: z
-      .enum(["keyword", "semantic", "hybrid"])
+    searchType: looseEnum(["keyword", "semantic", "hybrid"])
       .default("hybrid")
       .describe(
         "'keyword' for exact text matches, 'semantic' for meaning-based search, 'hybrid' for both (default)",

--- a/src/mastra/tools/zod-loose.ts
+++ b/src/mastra/tools/zod-loose.ts
@@ -65,3 +65,55 @@ export const looseNumber = (
   inner: z.ZodNumber = z.number(),
 ): z.ZodEffects<z.ZodNumber, number, number> =>
   z.preprocess(toNumber, inner) as z.ZodEffects<z.ZodNumber, number, number>;
+
+/**
+ * Tolerant enum input schemas for tool parameters.
+ *
+ * Models emit near-miss enum members constantly: `"In Progress"` for
+ * `IN_PROGRESS`, `"Binance"` for `binance`, `"1st priority"` for
+ * `"1st Priority"`. A bare `z.enum()` rejects all of these and the model burns
+ * a retry (or, with `.catch(default)`, the value is silently replaced with a
+ * wrong one — a data-integrity bug, see ADR-0001).
+ *
+ * `looseEnum` normalizes obvious near-misses to the canonical member, then
+ * validates. The match is done on a separator/case-insensitive key
+ * (lowercased, non-alphanumerics stripped), and we return the enum's OWN
+ * canonical spelling — so this works for `UPPER_SNAKE`, lowercase, and
+ * human-cased (`"1st Priority"`) enums alike, NOT just blind uppercasing.
+ *
+ * A value that can't be normalized to a member is returned UNCHANGED, so the
+ * inner `z.enum()` fails loud with the real Zod error listing valid values.
+ * That is correct self-correction (the model retries), not a bug — we coerce
+ * to preserve intent, we never invent it. Do NOT add `.catch(default)`: that
+ * substitutes a wrong value silently (the guard test bans it).
+ */
+const enumKey = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]+/g, "");
+
+export const normalizeEnumValue = (
+  values: readonly string[],
+  v: unknown,
+): unknown => {
+  if (typeof v !== "string") return v;
+  if (values.includes(v)) return v; // already canonical
+  const key = enumKey(v);
+  if (key === "") return v;
+  // First canonical member whose normalized key matches. Real enums here have
+  // no key collisions; if two ever did, first-declared wins (deterministic).
+  return values.find((val) => enumKey(val) === key) ?? v; // unmappable → fail loud
+};
+
+// `values` is passed straight to `z.enum` so its overloads drive literal-tuple
+// inference (re-specifying the generics here widens the members to `string`).
+// Output AND input are pinned to the inner enum's literal union — same white
+// lie as the scalar helpers: by the time `inputData` is read the value has been
+// normalized-and-validated into a real member, which is what call sites need
+// (e.g. indexing a Record keyed by the union).
+export const looseEnum = <U extends string, T extends Readonly<[U, ...U[]]>>(
+  values: T,
+) => {
+  const inner = z.enum(values);
+  return z.preprocess(
+    (v) => normalizeEnumValue(values, v),
+    inner,
+  ) as z.ZodEffects<typeof inner, z.infer<typeof inner>, z.infer<typeof inner>>;
+};


### PR DESCRIPTION
## What

Part of **Robust agent tool inputs (ADR-0001)**. Hardens model-facing `z.enum()` inputs against near-miss values without ever silently substituting a wrong one.

- **`looseEnum()`** (in `zod-loose.ts`) — a normalizing preprocess that maps near-misses to the enum's **own canonical member** on a separator/case-insensitive key: `"In Progress"→IN_PROGRESS`, `"Binance"→binance`, `"1st priority"→"1st Priority"`. Works for `UPPER_SNAKE`, lowercase, and human-cased enums (not blind uppercasing). An unmappable value is returned **unchanged** so the inner `z.enum` **fails loud** and the model retries — coerce to preserve intent, never invent it.
- **Swept ~45 model-facing enum fields across 12 tool files**, including enum fields nested in object-arrays (`tickets[].status`, `goals[].projects[].priority`, `sorts[].direction`) and the worst offenders (10-value ticket `status`, ticket `type`, the 11-value human-priority enum). Direct `z.array(z.enum())` (`insightTypes`) is **deferred to the arrays ticket (#4)**.
- **Guard extended** to fail on bare model-facing `z.enum()` **and** to ban `.catch()` over any model-facing enum/scalar (a silent default is the data-integrity bug this effort prevents). No `.catch` existed — the rule is now enforced going forward.

## Verification

- `npm run test`: **7 files / 76 tests green** (guard + expanded coercion table + `looseEnum` in isolation).
- Coercion tests: ticket `status`/`type`, the human-priority enum, OKR `health`, a lowercase exchange enum — near-miss coerces, canonical passes, unmappable throws.
- `tsc --noEmit`: **no new errors** vs `main`. Output/input generics on `looseEnum` are pinned to the inner enum's literal union, so call sites keep narrow types (Record indexing etc.).
- No `outputSchema` touched.

## Acceptance criteria

- [x] Normalizing enum-preprocess helper exists and is unit-tested (near-miss coerces; unmappable throws)
- [x] All model-facing scalar enum inputs use it; no `.catch(default)` on any write tool (none existed; now guarded)
- [x] Guard test extended to fail on unwrapped model-facing `z.enum()`
- [x] Coercion test covers ticket `status`/`type` and the human-priority enum
- [x] Full suite + guard green in CI

---

Ships: zippy.acorn

Depends on #30 (scalar guard) — already merged. Direct `z.array(z.enum())` deferred to wet.llama (#4).