### PR TITLE
refactor: array inputs — looseStringArray + array-of-enum + relax filter .email()

### DIFF
--- a/src/mastra/tools/index.ts
+++ b/src/mastra/tools/index.ts
@@ -9,7 +9,7 @@ import {
 } from "../utils/authenticated-fetch.js";
 import { prepareUntrustedContent, auditWriteAction } from "../utils/content-safety.js";
 import { asAppContext } from "../types/request-context.js";
-import { looseBoolean, looseNumber, looseEnum } from "./zod-loose.js";
+import { looseBoolean, looseNumber, looseEnum, looseStringArray, looseEnumArray } from "./zod-loose.js";
 
 interface GeocodingResponse {
   results: {
@@ -1044,8 +1044,7 @@ export const getMeetingTranscriptionsTool = createTool({
       .optional()
       .describe("Start date filter in ISO format"),
     endDate: z.string().optional().describe("End date filter in ISO format"),
-    participants: z
-      .array(z.string())
+    participants: looseStringArray()
       .optional()
       .describe("Filter by participant names/IDs"),
     meetingType: z
@@ -1254,17 +1253,14 @@ export const getMeetingInsightsTool = createTool({
       .string()
       .optional()
       .describe("Custom end date if timeframe is custom"),
-    insightTypes: z
-      .array(
-        z.enum([
-          "decisions",
-          "action_items",
-          "deadlines",
-          "blockers",
-          "milestones",
-          "team_updates",
-        ])
-      )
+    insightTypes: looseEnumArray([
+      "decisions",
+      "action_items",
+      "deadlines",
+      "blockers",
+      "milestones",
+      "team_updates",
+    ])
       .optional()
       .describe("Types of insights to extract"),
   }),
@@ -2038,7 +2034,7 @@ export const searchCrmContactsTool = createTool({
     "Search contacts in the CRM by name, tags, or organization. Returns a list of matching contacts with basic info. Use this to find contacts before getting full details or logging interactions.",
   inputSchema: z.object({
     search: z.string().optional().describe("Search by first or last name"),
-    tags: z.array(z.string()).optional().describe("Filter by tags (e.g., ['investor', 'advisor'])"),
+    tags: looseStringArray().optional().describe("Filter by tags (e.g., ['investor', 'advisor'])"),
     organizationId: z.string().optional().describe("Filter by organization ID"),
     limit: looseNumber(z.number()).default(20).describe("Max results to return (default: 20)"),
   }),
@@ -2171,8 +2167,8 @@ export const createFullCrmContactTool = createTool({
     twitter: z.string().optional().describe("Twitter/X handle"),
     github: z.string().optional().describe("GitHub username"),
     about: z.string().optional().describe("Notes about this contact"),
-    skills: z.array(z.string()).optional().describe("Contact's skills"),
-    tags: z.array(z.string()).optional().describe("Tags for categorization"),
+    skills: looseStringArray().optional().describe("Contact's skills"),
+    tags: looseStringArray().optional().describe("Tags for categorization"),
     organizationId: z.string().optional().describe("Organization to link this contact to"),
   }),
   outputSchema: z.object({
@@ -2224,8 +2220,8 @@ export const updateCrmContactTool = createTool({
     twitter: z.string().optional().nullable().describe("Updated Twitter handle"),
     github: z.string().optional().nullable().describe("Updated GitHub username"),
     about: z.string().optional().describe("Updated notes"),
-    skills: z.array(z.string()).optional().describe("Updated skills list (replaces existing)"),
-    tags: z.array(z.string()).optional().describe("Updated tags list (replaces existing)"),
+    skills: looseStringArray().optional().describe("Updated skills list (replaces existing)"),
+    tags: looseStringArray().optional().describe("Updated tags list (replaces existing)"),
     organizationId: z.string().optional().nullable().describe("Organization ID (null to unlink)"),
   }),
   outputSchema: z.object({

--- a/src/mastra/tools/keystone-guard.test.ts
+++ b/src/mastra/tools/keystone-guard.test.ts
@@ -93,6 +93,18 @@ function isLooseWrapped(schema: any, innerTypes: string[]): boolean {
 }
 const isLooseWrappedScalar = (s: any) => isLooseWrapped(s, ['ZodNumber', 'ZodBoolean']);
 const isLooseWrappedEnum = (s: any) => isLooseWrapped(s, ['ZodEnum']);
+// looseStringArray/looseEnumArray = preprocess over a ZodArray whose element is
+// a string or enum.
+function isLooseWrappedArray(schema: any): boolean {
+  const u = unwrap(schema);
+  if (u?._def?.typeName === 'ZodEffects' && u._def.effect?.type === 'preprocess') {
+    const innerArr = unwrap(u._def.schema);
+    if (innerArr?._def?.typeName !== 'ZodArray') return false;
+    const el = unwrap(innerArr._def.type)?._def?.typeName;
+    return el === 'ZodString' || el === 'ZodEnum';
+  }
+  return false;
+}
 
 // Does the optional/default/nullable/catch wrapper chain over this field
 // contain a `.catch()` guarding a model-facing enum/scalar? `.catch(default)`
@@ -127,19 +139,21 @@ interface Violation {
 }
 
 // Recursively collect every model-facing input that breaks a swept convention:
-//   • bare z.number()/z.boolean()      (scalars — deep.rune)
-//   • bare z.enum()                    (enums   — zippy.acorn)
-//   • a `.catch()` over any of those   (banned  — zippy.acorn)
-// A direct `z.array(z.enum())` (array-of-enum) is deferred to wet.llama (#4),
-// so its element enum is NOT flagged here. Enums nested inside an object that
-// happens to live in an array (e.g. `tickets[].status`) ARE flagged — they are
-// ordinary enum fields. Output schemas are never walked (not model-produced).
+//   • bare z.number()/z.boolean()              (scalars — deep.rune)
+//   • bare z.enum()                            (enums   — zippy.acorn)
+//   • a `.catch()` over any of those           (banned  — zippy.acorn)
+//   • bare z.array(z.string())/z.array(z.enum()) (arrays — wet.llama)
+// Enums/strings nested inside an object that happens to live in an array (e.g.
+// `tickets[].status`) are still walked as ordinary fields. Output schemas are
+// never walked (not model-produced).
 function findViolations(schema: any, path: string, out: Violation[]): void {
   if (hasCatchOverGuardedClass(schema)) {
     out.push({ path, reason: '.catch() is banned on model-facing enums/scalars — use looseEnum/looseNumber/looseBoolean (normalize-then-fail, never silent-default)' });
     return;
   }
-  if (isLooseWrappedScalar(schema) || isLooseWrappedEnum(schema)) return; // properly wrapped
+  if (isLooseWrappedScalar(schema) || isLooseWrappedEnum(schema) || isLooseWrappedArray(schema)) {
+    return; // properly wrapped
+  }
   const u = unwrap(schema);
   if (!u?._def) return;
   const tn = u._def.typeName;
@@ -158,8 +172,21 @@ function findViolations(schema: any, path: string, out: Violation[]): void {
       findViolations(shape[key], `${path}.${key}`, out);
     }
   } else if (tn === 'ZodArray') {
-    // Direct array-of-enum is wet.llama's (#4) territory — skip its element.
-    if (unwrap(u._def.type)?._def?.typeName === 'ZodEnum') return;
+    // A bare array-of-string / array-of-enum must use looseStringArray() /
+    // looseEnumArray() (the field itself was not loose-wrapped, else we'd have
+    // returned above). Arrays of objects/other are not a string-array class —
+    // recurse so their inner fields are still checked.
+    const elType = unwrap(u._def.type)?._def?.typeName;
+    if (elType === 'ZodString' || elType === 'ZodEnum') {
+      out.push({
+        path,
+        reason:
+          elType === 'ZodEnum'
+            ? 'bare z.array(z.enum()) — wrap in looseEnumArray([...])'
+            : 'bare z.array(z.string()) — wrap in looseStringArray()',
+      });
+      return;
+    }
     findViolations(u._def.type, `${path}[]`, out);
   } else if (tn === 'ZodUnion') {
     (u._def.options ?? []).forEach((opt: any, i: number) =>

--- a/src/mastra/tools/meeting-context-tools.ts
+++ b/src/mastra/tools/meeting-context-tools.ts
@@ -2,7 +2,7 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { authenticatedTrpcCall } from "../utils/authenticated-fetch.js";
 import { asAppContext } from "../types/request-context.js";
-import { looseNumber, looseEnum } from "./zod-loose.js";
+import { looseNumber, looseEnum, looseStringArray } from "./zod-loose.js";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Meeting Context Tools
@@ -351,8 +351,10 @@ export const findRelatedMeetingsTool = createTool({
       .string()
       .min(1)
       .describe("Title of the upcoming meeting to match against past titles"),
-    participantEmails: z
-      .array(z.string().email())
+    // Read-only filter: per-element .email() is relaxed to plain string. A bad
+    // email matches nothing (harmless); rejecting the whole query over one typo
+    // is strictly worse. looseStringArray also accepts comma/JSON-string shapes.
+    participantEmails: looseStringArray()
       .default([])
       .describe(
         "Attendee emails for the upcoming meeting; used for participant-overlap scoring",

--- a/src/mastra/tools/one2b-tools.ts
+++ b/src/mastra/tools/one2b-tools.ts
@@ -1,7 +1,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { one2bTrpcMutation, one2bTrpcQuery, serperSearch } from "../utils/one2b-api.js";
-import { looseEnum } from "./zod-loose.js";
+import { looseEnum, looseStringArray } from "./zod-loose.js";
 
 // ─── Track definitions ──────────────────────────────────────────────────────
 // Each track maps to a specific tRPC router on the One2b platform.
@@ -278,7 +278,7 @@ export const one2bCreateLeadTool = createTool({
     // Communication preferences (required by most tracks)
     mobileContactMethod: z.string().optional().describe("Preferred mobile contact: WhatsApp, Signal, Telegram, SMS"),
     videoCallPlatform: z.string().optional().describe("Preferred video call: Zoom, Teams, Google Meet"),
-    preferredContactTimes: z.array(z.string()).optional().describe("Preferred times: Morning, Afternoon, Evening"),
+    preferredContactTimes: looseStringArray().optional().describe("Preferred times: Morning, Afternoon, Evening"),
     timeZone: z.string().optional().describe("Contact's timezone"),
     // Track-specific data collected during conversation
     trackData: z.record(z.unknown()).optional().describe(

--- a/src/mastra/tools/tool-input-coercion.test.ts
+++ b/src/mastra/tools/tool-input-coercion.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { z } from 'zod';
-import { looseEnum, normalizeEnumValue } from './zod-loose.js';
+import {
+  looseEnum,
+  normalizeEnumValue,
+  looseStringArray,
+  looseEnumArray,
+} from './zod-loose.js';
 
 // Regression guard for the failure class documented in zod-loose.ts: the model
 // (Haiku especially) emits JSON-stringified scalars ("19", "false") instead of
@@ -35,6 +40,7 @@ const {
   getMeetingTranscriptionsTool,
   findAvailableTimeSlotsTool,
   createProjectActionTool,
+  getMeetingInsightsTool,
 } = await import('./index.js');
 const { bulkCreateWorkspaceStructureTool, deleteProjectTool } = await import(
   './project-tools.js'
@@ -243,5 +249,63 @@ describe('looseEnum helper in isolation', () => {
     expect(schema.parse('HIGH')).toBe('high');
     expect(schema.parse('low')).toBe('low');
     expect(() => schema.parse('medium')).toThrow();
+  });
+});
+
+// ── Array inputs (wet.llama) ────────────────────────────────────────────────
+// The model emits string[] fields as comma-strings or JSON-string arrays.
+// looseStringArray accepts all three shapes; looseEnumArray additionally
+// normalizes each element. Read-filter .email() is relaxed to plain string.
+
+describe('looseStringArray helper in isolation', () => {
+  it('accepts a native array, a JSON-string array, and a comma-string', () => {
+    const schema = looseStringArray();
+    expect(schema.parse(['a', 'b'])).toEqual(['a', 'b']); // native
+    expect(schema.parse('["a","b"]')).toEqual(['a', 'b']); // JSON-string
+    expect(schema.parse('a, b')).toEqual(['a', 'b']); // comma-string
+  });
+
+  it('trims and drops empties (so "" → [])', () => {
+    const schema = looseStringArray();
+    expect(schema.parse('')).toEqual([]);
+    expect(schema.parse('a, , b,')).toEqual(['a', 'b']);
+    expect(schema.parse(' x ,y')).toEqual(['x', 'y']);
+  });
+});
+
+describe('array fields on real tools', () => {
+  it('getMeetingTranscriptionsTool.participants: comma-string → array', () => {
+    expect(parseField(getMeetingTranscriptionsTool, 'participants', 'Alice, Bob')).toEqual([
+      'Alice',
+      'Bob',
+    ]);
+    expect(parseField(getMeetingTranscriptionsTool, 'participants', ['Alice'])).toEqual(['Alice']);
+  });
+
+  it('findRelatedMeetingsTool.participantEmails: .email() relaxed — a bad email is kept, not rejected', () => {
+    // A typo in a read filter matches nothing (harmless); rejecting the whole
+    // query would be strictly worse. Plain strings, comma-split, no .email().
+    expect(parseField(findRelatedMeetingsTool, 'participantEmails', 'a@b.com, not-an-email')).toEqual([
+      'a@b.com',
+      'not-an-email',
+    ]);
+  });
+
+  it('getMeetingInsightsTool.insightTypes: split + per-element enum normalize, unmappable fails loud', () => {
+    expect(parseField(getMeetingInsightsTool, 'insightTypes', 'decisions, action_items')).toEqual([
+      'decisions',
+      'action_items',
+    ]);
+    // near-miss element normalizes to canonical
+    expect(parseField(getMeetingInsightsTool, 'insightTypes', 'Action Items')).toEqual(['action_items']);
+    expect(parseField(getMeetingInsightsTool, 'insightTypes', ['deadlines'])).toEqual(['deadlines']);
+    // an unmappable element fails loud rather than being silently dropped
+    expect(() => parseField(getMeetingInsightsTool, 'insightTypes', 'decisions, nonsense')).toThrow();
+  });
+
+  it('looseEnumArray in isolation: splits, normalizes, and rejects unmappable', () => {
+    const schema = looseEnumArray(['decisions', 'action_items']);
+    expect(schema.parse('Decisions, action items')).toEqual(['decisions', 'action_items']);
+    expect(() => schema.parse('decisions, bogus')).toThrow();
   });
 });

--- a/src/mastra/tools/zod-loose.ts
+++ b/src/mastra/tools/zod-loose.ts
@@ -117,3 +117,60 @@ export const looseEnum = <U extends string, T extends Readonly<[U, ...U[]]>>(
     inner,
   ) as z.ZodEffects<typeof inner, z.infer<typeof inner>, z.infer<typeof inner>>;
 };
+
+/**
+ * Tolerant string-array input schemas for tool parameters.
+ *
+ * Models routinely emit a `string[]` field as a comma-string (`"investor,
+ * advisor"`) or a JSON-string array (`'["investor","advisor"]'`) instead of a
+ * native array. A bare `z.array(z.string())` rejects both. `toStringArray`
+ * accepts a native array (pass through), a JSON-string array (parse), or a
+ * comma-string (split on commas + optional whitespace, trim, and drop empties
+ * so an empty string becomes an empty array).
+ */
+const toStringArray = (v: unknown): unknown => {
+  if (Array.isArray(v)) return v;
+  if (typeof v === "string") {
+    const s = v.trim();
+    if (s === "") return [];
+    if (s.startsWith("[")) {
+      try {
+        const parsed: unknown = JSON.parse(s);
+        if (Array.isArray(parsed)) return parsed;
+      } catch {
+        // not valid JSON — fall through to comma-splitting
+      }
+    }
+    return s
+      .split(/,\s*/)
+      .map((x) => x.trim())
+      .filter((x) => x !== "");
+  }
+  return v; // fall through — inner z.array() rejects anything unexpected
+};
+
+export const looseStringArray = (
+  inner: z.ZodArray<z.ZodString> = z.array(z.string()),
+): z.ZodEffects<z.ZodArray<z.ZodString>, string[], string[]> =>
+  z.preprocess(toStringArray, inner) as z.ZodEffects<
+    z.ZodArray<z.ZodString>,
+    string[],
+    string[]
+  >;
+
+/**
+ * Tolerant `z.array(z.enum())` input. Splits the comma/JSON-string shapes the
+ * same way as {@link looseStringArray}, then runs each element through the enum
+ * normalizer ({@link normalizeEnumValue}) so near-miss members coerce to
+ * canonical. Any element that still can't be mapped is left unchanged, so the
+ * inner `z.array(z.enum())` fails loud — coerce to preserve intent, never invent.
+ */
+export const looseEnumArray = <U extends string, T extends Readonly<[U, ...U[]]>>(
+  values: T,
+) => {
+  const inner = z.array(z.enum(values));
+  return z.preprocess((v) => {
+    const arr = toStringArray(v);
+    return Array.isArray(arr) ? arr.map((el) => normalizeEnumValue(values, el)) : arr;
+  }, inner) as z.ZodEffects<typeof inner, z.infer<typeof inner>, z.infer<typeof inner>>;
+};


### PR DESCRIPTION
## What

Final ticket of **Robust agent tool inputs (ADR-0001)**. Hardens model-facing array inputs against the comma-string / JSON-string shapes the model emits for `string[]`.

- **`looseStringArray()`** (in `zod-loose.ts`) accepts a native array, a JSON-string array (`'["a","b"]'`), or a comma-string (`"a, b"`) — split on commas, trim, **drop empties** so `""` → `[]`.
- **`looseEnumArray([...])`** splits the same way, then runs each element through the enum normalizer (#3): a near-miss member coerces, an unmappable one **fails loud**.
- **Swept all model-facing array inputs**: CRM `tags`/`skills` (writes), meeting `participants` + one2b `preferredContactTimes` → `looseStringArray`; `getMeetingInsightsTool.insightTypes` (array-of-enum) → `looseEnumArray`.
- **Relaxed per-element `.email()`** on `findRelatedMeetingsTool.participantEmails` (a read filter) to plain string. A bad email in a filter matches nothing (harmless); rejecting the whole query over one typo is strictly worse, and a filter can't corrupt anything — consistent with fail-loud protecting *writes*.
- **Guard extended** to flag bare `z.array(z.string())` / `z.array(z.enum())`; array-of-enum is no longer deferred.

## Verification

- `npm run test`: **7 files / 82 tests green** (guard + array coercion table + helpers in isolation).
- Tests: comma-string splits, JSON-string parses, empties dropped, near-miss enum element normalizes, unmappable element throws, relaxed filter email kept.
- `tsc --noEmit`: **no new errors** vs `main`.
- No `outputSchema` touched.

## Acceptance criteria

- [x] `looseStringArray()` handles array / JSON-string / comma-string, drops empties; unit-tested
- [x] `z.array(z.enum())` inputs compose split + the #3 enum normalizer (unmappable element fails loud)
- [x] Per-element `.email()` relaxed to plain string on read filter fields
- [x] All model-facing array inputs swept; guard extended to arrays
- [x] Full suite + guard green in CI

---

Ships: wet.llama

Depends on #32 (enum normalizer) — already merged. Completes ADR-0001 Tier 0 + Tier A.