### PR TITLE
fix(tools): quick-create honours stated priority & resolved project

### DIFF
--- a/src/mastra/agents/assistant-agent.ts
+++ b/src/mastra/agents/assistant-agent.ts
@@ -113,9 +113,13 @@ If no personality is provided, be helpful, concise, and friendly with a natural 
 You have real tools that create, read, and update data. When someone asks you to do something actionable, call the tool — don't describe what they *could* do or give them instructions on how to do it themselves.
 
 ### Action & Task Management
-- **quick-create-action**: Create actions from natural language. Parses dates ("tomorrow", "next Monday", "Friday") and matches project names automatically. This is your default for creating tasks.
-- **create-project-action**: Create actions with explicit projectId, name, priority (Quick/Short/Long/Research), and optional description/dueDate.
+- **quick-create-action**: Create actions from natural language. Parses dates ("tomorrow", "next Monday", "Friday") and matches project names automatically. This is your default for creating tasks. Optionally pass \`priority\` (only when the user states one) and \`projectId\` (a project id you resolved via get-all-projects) — both honoured, with \`projectId\` winning over the current page.
+- **create-project-action**: Create actions with explicit projectId, name, priority, and optional description/dueDate. Use when you already have the project ID and want precise control.
 - **update-action**: Update an existing action's fields — rename it, change priority/status, set due dates, or move it to a different project by setting a new projectId. Set projectId to null to unassign from any project.
+
+**Priority values** are exactly: \`Quick\`, \`Scheduled\`, \`1st Priority\`, \`2nd Priority\`, \`3rd Priority\`, \`4th Priority\`, \`5th Priority\`, \`Errand\`, \`Remember\`, \`Watch\`, \`Someday Maybe\`. Only set a priority when the user expresses one — otherwise omit it and the action defaults to \`Quick\`. Map natural language: "highest"/"urgent"/"ASAP"/"as high as possible" → \`1st Priority\`; "high" → \`2nd Priority\`; "medium" → \`3rd Priority\`; "low" → \`4th Priority\` (or \`5th Priority\` for "lowest").
+
+**Resolving a named project:** when the user names a project (possibly mis-transcribed from voice), call get-all-projects, pick the best match by name, and pass its real \`projectId\` — do **not** rely on the current page context. An explicitly passed \`projectId\` files the action there even if the user is viewing a different project, and works for shared/team projects the user can access but didn't create.
 
 ### Project Intelligence
 - **get-all-projects**: List projects (ACTIVE by default, pass includeAll=true for all statuses).

--- a/src/mastra/agents/zoe-agent.ts
+++ b/src/mastra/agents/zoe-agent.ts
@@ -127,10 +127,14 @@ You're not a chatbot. You're not a productivity bot. You're something between a 
 You have real tools that create, read, and update data. When someone asks you to do something actionable, call the tool — don't describe what they *could* do or give them instructions on how to do it themselves.
 
 ### Action & Task Management
-- **quick-create-action**: Create actions from natural language. Parses dates ("tomorrow", "next Monday", "Friday") and matches project names from the text automatically. This is your default for creating tasks — pass the user's request as-is in the \`text\` parameter.
+- **quick-create-action**: Create actions from natural language. Parses dates ("tomorrow", "next Monday", "Friday") and matches project names from the text automatically. This is your default for creating tasks — pass the user's request as-is in the \`text\` parameter. Optionally pass \`priority\` (only when the user states one) and \`projectId\` (a project id you resolved via get-all-projects) — both honoured, with \`projectId\` winning over the current page.
   Example call: { "text": "Review the Operating Agreement for Commons Lab Exec tomorrow" }
-- **create-project-action**: Create actions with explicit projectId, name, priority (Quick/Short/Long/Research), and optional description/dueDate. Use when you already have the project ID and want precise control over priority or description.
+- **create-project-action**: Create actions with explicit projectId, name, priority, and optional description/dueDate. Use when you already have the project ID and want precise control over priority or description.
 - **update-action**: Update an existing action's fields — rename it, change priority/status, set due dates, or move it to a different project by setting a new projectId. Set projectId to null to unassign from any project.
+
+**Priority values** are exactly: \`Quick\`, \`Scheduled\`, \`1st Priority\`, \`2nd Priority\`, \`3rd Priority\`, \`4th Priority\`, \`5th Priority\`, \`Errand\`, \`Remember\`, \`Watch\`, \`Someday Maybe\`. Only set a priority when the user expresses one — otherwise omit it and the action defaults to \`Quick\`. Map natural language: "highest"/"urgent"/"ASAP"/"as high as possible" → \`1st Priority\`; "high" → \`2nd Priority\`; "medium" → \`3rd Priority\`; "low" → \`4th Priority\` (or \`5th Priority\` for "lowest").
+
+**Resolving a named project:** when the user names a project (possibly mis-transcribed from voice), call get-all-projects, pick the best match by name, and pass its real \`projectId\` — do **not** rely on the current page context. An explicitly passed \`projectId\` files the action there even if the user is viewing a different project, and works for shared/team projects the user can access but didn't create.
 
 ### Project Intelligence
 - **get-all-projects**: List projects (ACTIVE by default, pass includeAll=true for all statuses). Use this to orient yourself — find project IDs, see what's active, get the lay of the land.

--- a/src/mastra/tools/index.ts
+++ b/src/mastra/tools/index.ts
@@ -642,7 +642,7 @@ export const createProjectActionTool = createTool({
 export const quickCreateActionTool = createTool({
   id: "quick-create-action",
   description:
-    "Create a new action using natural language. Pass the action description in the `text` parameter — e.g. { \"text\": \"Call John tomorrow\" }. Automatically parses dates like 'tomorrow' or 'next Monday' and matches project names from the text. Use this when the user wants to create an action without specifying project ID or priority explicitly.",
+    "Create a new action using natural language. Pass the action description in the `text` parameter — e.g. { \"text\": \"Call John tomorrow\" }. Automatically parses dates like 'tomorrow' or 'next Monday' and matches project names from the text. Optionally pass an explicit `priority` (when the user states one) and/or a resolved `projectId` (when the user names a project — resolve it to a real id via get-all-projects first). An explicit `projectId` wins over the page context.",
   inputSchema: z.object({
     text: z
       .string()
@@ -657,6 +657,13 @@ export const quickCreateActionTool = createTool({
       .string()
       .optional()
       .describe("Alias for `text` — prefer `text`."),
+    priority: looseEnum(["Quick", "Scheduled", "1st Priority", "2nd Priority", "3rd Priority", "4th Priority", "5th Priority", "Errand", "Remember", "Watch", "Someday Maybe"])
+      .optional()
+      .describe("Action priority. Only set this when the user expresses a priority; otherwise omit it and the action defaults to 'Quick'. Map natural language: 'highest'/'urgent'/'ASAP' → '1st Priority', 'high' → '2nd Priority', 'medium' → '3rd Priority', 'low' → '4th Priority' or '5th Priority'."),
+    projectId: z
+      .string()
+      .optional()
+      .describe("Explicit project id to file the action under. Resolve a user-named project to its real id via get-all-projects and pass it here — it takes precedence over the current page context. Omit to fall back to the page context / text-matched project."),
   }),
   outputSchema: z.object({
     success: z.boolean(),
@@ -692,7 +699,7 @@ export const quickCreateActionTool = createTool({
     const authToken = requestContext?.get("authToken");
     const sessionId = requestContext?.get("whatsappSession");
     const userId = requestContext?.get("userId");
-    const projectId = requestContext?.get("projectId");
+    const contextProjectId = requestContext?.get("projectId");
 
     const text = inputData.text ?? inputData.input;
     if (!text) {
@@ -701,9 +708,13 @@ export const quickCreateActionTool = createTool({
       );
     }
 
-    console.log(`🎯 [quickCreateAction] INPUT: text="${text}"`);
-    console.log(`🎯 [quickCreateAction] CONTEXT: authToken=${authToken ? "present" : "MISSING"}, userId=${userId || "none"}, projectId=${projectId || "none"}`);
-    console.log(`🎯 [quickCreateAction] SENDING TO TRPC: { text: "${text}", projectId: ${projectId ? `"${projectId}"` : "undefined"} }`);
+    // An explicitly-resolved projectId from the model wins over the page context.
+    const projectId = inputData.projectId ?? contextProjectId;
+    const priority = inputData.priority;
+
+    console.log(`🎯 [quickCreateAction] INPUT: text="${text}", priority=${priority || "none"}, inputProjectId=${inputData.projectId || "none"}`);
+    console.log(`🎯 [quickCreateAction] CONTEXT: authToken=${authToken ? "present" : "MISSING"}, userId=${userId || "none"}, contextProjectId=${contextProjectId || "none"}, resolvedProjectId=${projectId || "none"}`);
+    console.log(`🎯 [quickCreateAction] SENDING TO TRPC: { text: "${text}", projectId: ${projectId ? `"${projectId}"` : "undefined"}, priority: ${priority ? `"${priority}"` : "undefined"} }`);
 
     if (!authToken) {
       throw new Error("No authentication token available");
@@ -712,7 +723,7 @@ export const quickCreateActionTool = createTool({
     try {
       const { data: result } = await authenticatedTrpcCall(
         "mastra.quickCreateAction",
-        { text, projectId: projectId || undefined },
+        { text, projectId: projectId || undefined, priority: priority || undefined },
         { authToken, sessionId, userId }
       );
 


### PR DESCRIPTION
Companion to exponential PRs #221/#222 (PRD alpha.dune, ticket windy.dahlia). The exponential endpoint side is already merged + deployed; this is the mastra side that actually populates the new inputs.

## What
- **quick-create-action** tool gains optional `priority` (canonical 11-value enum, mirroring `create-project-action`) and optional `projectId`, forwarding both to `mastra.quickCreateAction`. An explicitly-resolved `projectId` wins over the page context; both fall back to prior behaviour when omitted.
- **Agent instructions** (assistant + Zoe): fix the wrong priority list (`Quick/Short/Long/Research`) → the real enum; add natural-language → enum mapping (highest/urgent → 1st Priority, high → 2nd, medium → 3rd, low → 4th/5th; default `Quick` when unstated); instruct resolving a user-named project to a real `projectId` via get-all-projects rather than relying on the page context.

No behaviour change when neither input is supplied.

Refs: windy.dahlia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced priority management: AI assistants now explicitly set task priorities (urgent, high, medium, low) when creating or updating actions.
  * Improved project resolution: Assistants now accurately resolve project names and explicitly pass project IDs, reducing reliance on page context for more reliable action management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->