### PR TITLE
feat(whatsapp): periodic channel summarizer job (ADR-0023)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,9 @@ Key variables (see documentation in `/docs` for setup details):
 - `WHATSAPP_MAX_SESSIONS` - Max concurrent WhatsApp sessions (default: 10)
 - `AUTH_SECRET` - JWT signing secret (must match client app's secret for gateway auth)
 - `GATEWAY_SECRET` - Shared secret for token refresh (falls back to `WHATSAPP_GATEWAY_SECRET`)
+- `WHATSAPP_CAPTURE_GROUP_JIDS` - Comma-separated group JIDs the gateway captures/summarizes (the *watching* allowlist)
+- `ENABLE_CHANNEL_SUMMARIZER` - Enable the periodic channel summarizer job (default: false). When `true`, summarizes each watched group's traffic since its last summary and POSTs one summary per window to exponential's `mastra.recordChannelSummary` (ADR-0023). Posts via the connected user's agent JWT to `TODO_APP_BASE_URL`; raw messages never leave mastra.
+- `WHATSAPP_SUMMARY_INTERVAL_HOURS` - Channel summarizer cadence in hours (default: 24)
 
 ### Server Configuration
 

--- a/src/mastra/bots/channel-summary-store.ts
+++ b/src/mastra/bots/channel-summary-store.ts
@@ -1,0 +1,126 @@
+/**
+ * channel-summary-store — mastra-side persistence for the periodic channel
+ * summarizer (ADR-0023, exponential repo).
+ *
+ * Two jobs, both against mastra's own Postgres (the `whatsapp_messages` schema,
+ * same DATABASE_URL the WhatsApp message store uses):
+ *   1. A small per-(user, group) `channel_watermarks` row holding
+ *      `last_summarized_at` — the watermark advanced only after exponential
+ *      confirms receipt of a summary.
+ *   2. Read-only access to the captured messages in a half-open window for one
+ *      group, plus the group's display name.
+ *
+ * Raw messages NEVER leave mastra — this module only reads them to build a
+ * summary in-process; only the finished summary is pushed to exponential.
+ */
+import pg from 'pg';
+
+const SCHEMA_NAME = 'whatsapp_messages';
+
+let pool: pg.Pool | null = null;
+let initPromise: Promise<void> | null = null;
+
+function getPool(): pg.Pool {
+  pool ??= new pg.Pool({ connectionString: process.env.DATABASE_URL });
+  return pool;
+}
+
+/** Lazily create the watermark table (idempotent; mastra has no migrations). */
+async function ensureInitialized(): Promise<void> {
+  initPromise ??= getPool().query(`
+    CREATE TABLE IF NOT EXISTS ${SCHEMA_NAME}.channel_watermarks (
+      user_id            TEXT NOT NULL,
+      jid                TEXT NOT NULL,
+      last_summarized_at TIMESTAMPTZ NOT NULL,
+      updated_at         TIMESTAMPTZ DEFAULT NOW(),
+      PRIMARY KEY (user_id, jid)
+    )
+  `).then(() => undefined);
+  return initPromise;
+}
+
+export interface WindowMessage {
+  senderName: string | null;
+  text: string;
+  timestamp: Date;
+}
+
+/** The watermark for a group, or `null` if it has never been summarized. */
+export async function getLastSummarizedAt(
+  userId: string,
+  jid: string,
+): Promise<Date | null> {
+  await ensureInitialized();
+  const { rows } = await getPool().query<{ last_summarized_at: Date }>(
+    `SELECT last_summarized_at FROM ${SCHEMA_NAME}.channel_watermarks
+     WHERE user_id = $1 AND jid = $2`,
+    [userId, jid],
+  );
+  return rows[0]?.last_summarized_at ?? null;
+}
+
+/** Advance (upsert) the watermark. Call ONLY after a confirmed 2xx delivery. */
+export async function setLastSummarizedAt(
+  userId: string,
+  jid: string,
+  at: Date,
+): Promise<void> {
+  await ensureInitialized();
+  await getPool().query(
+    `INSERT INTO ${SCHEMA_NAME}.channel_watermarks (user_id, jid, last_summarized_at, updated_at)
+     VALUES ($1, $2, $3, NOW())
+     ON CONFLICT (user_id, jid)
+     DO UPDATE SET last_summarized_at = EXCLUDED.last_summarized_at, updated_at = NOW()`,
+    [userId, jid, at],
+  );
+}
+
+/**
+ * Captured messages for a group in the half-open window `(start, end]`, oldest
+ * first. `start` may be `null` for the first-ever window (no lower bound).
+ */
+export async function readWindowMessages(
+  userId: string,
+  jid: string,
+  start: Date | null,
+  end: Date,
+): Promise<WindowMessage[]> {
+  const params: unknown[] = [userId, jid, end];
+  let lowerBound = '';
+  if (start) {
+    params.push(start);
+    lowerBound = `AND timestamp > $4`;
+  }
+  const { rows } = await getPool().query<{
+    sender_name: string | null;
+    text: string;
+    timestamp: Date;
+  }>(
+    `SELECT sender_name, text, timestamp
+     FROM ${SCHEMA_NAME}.messages
+     WHERE user_id = $1 AND jid = $2 AND timestamp <= $3 ${lowerBound}
+     ORDER BY timestamp ASC`,
+    params,
+  );
+  return rows.map((r) => ({
+    senderName: r.sender_name,
+    text: r.text,
+    timestamp: r.timestamp,
+  }));
+}
+
+/** Human-readable group name from the captured chat row, else `null`. */
+export async function getGroupDisplayName(
+  userId: string,
+  jid: string,
+): Promise<string | null> {
+  const { rows } = await getPool().query<{
+    contact_name: string | null;
+    push_name: string | null;
+  }>(
+    `SELECT contact_name, push_name FROM ${SCHEMA_NAME}.chats
+     WHERE user_id = $1 AND jid = $2`,
+    [userId, jid],
+  );
+  return rows[0]?.contact_name ?? rows[0]?.push_name ?? null;
+}

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -13,7 +13,7 @@ import { startVoiceGateway, cleanupVoiceGateway } from './bots/voice-gateway.js'
 import { initSentry, captureException, flushSentry } from './utils/sentry.js';
 import { assertAgentsValid } from './utils/validate-agents.js';
 import { computeBrainVersions, agentIdFromPath, BRAIN_VERSION_HEADER } from './utils/brain-version.js';
-import { startScheduler, stopScheduler, triggerCheck, deliverWhatsAppBriefings } from './proactive/index.js';
+import { startScheduler, stopScheduler, triggerCheck, deliverWhatsAppBriefings, startChannelSummarizer, stopChannelSummarizer } from './proactive/index.js';
 import { startSpanRetention, stopSpanRetention } from './utils/span-retention.js';
 import jwt from 'jsonwebtoken';
 import { createHmac, timingSafeEqual } from 'crypto';
@@ -261,6 +261,12 @@ if (enableProactive) {
   logger.info('📵 [MAIN] Proactive scheduler disabled (set ENABLE_PROACTIVE_SCHEDULER=true to enable)');
 }
 
+// Periodic channel summarizer (ADR-0023): summarizes watched WhatsApp groups
+// and pushes one summary per window to exponential. Opt-in via
+// ENABLE_CHANNEL_SUMMARIZER=true so it never fires against prod data on a local
+// `mastra dev` boot.
+startChannelSummarizer();
+
 // Daily prune of AI tracing spans (exponential-gnui). Railway-only: local
 // dev points at a shared DB it shouldn't be deleting from.
 if (isRailway) {
@@ -297,6 +303,7 @@ const shutdown = async (signal: string, error?: Error) => {
     
     // Stop proactive scheduler
     stopScheduler();
+    stopChannelSummarizer();
 
     // Flush Sentry events before exit
     await flushSentry();

--- a/src/mastra/proactive/channel-summarizer.test.ts
+++ b/src/mastra/proactive/channel-summarizer.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  computeWindow,
+  shouldPost,
+  runChannelSummarizer,
+  type ChannelSummarizerDeps,
+  type WindowMessage,
+} from './channel-summarizer.js';
+
+describe('computeWindow', () => {
+  const now = new Date('2026-06-17T10:00:00.000Z');
+
+  it('returns the half-open window since the last watermark', () => {
+    const last = new Date('2026-06-16T10:00:00.000Z');
+    expect(computeWindow(last, now)).toEqual({ start: last, end: now });
+  });
+
+  it('bootstraps to one interval before now on the first run', () => {
+    expect(computeWindow(null, now, 24)).toEqual({
+      start: new Date('2026-06-16T10:00:00.000Z'),
+      end: now,
+    });
+  });
+
+  it('honors a custom interval for the bootstrap window', () => {
+    expect(computeWindow(null, now, 6)).toEqual({
+      start: new Date('2026-06-17T04:00:00.000Z'),
+      end: now,
+    });
+  });
+});
+
+describe('shouldPost', () => {
+  it('is false when there were no messages', () => {
+    expect(shouldPost(0, 'something')).toBe(false);
+  });
+
+  it('is false when the model returns an empty / whitespace result', () => {
+    expect(shouldPost(5, '')).toBe(false);
+    expect(shouldPost(5, '   \n  ')).toBe(false);
+  });
+
+  it('is true when there were messages and a non-empty summary', () => {
+    expect(shouldPost(3, 'Alice shipped the release.')).toBe(true);
+  });
+});
+
+const NOW = new Date('2026-06-17T10:00:00.000Z');
+const JID = '123@g.us';
+const LAST = new Date('2026-06-16T10:00:00.000Z');
+
+function msg(text: string): WindowMessage {
+  return { senderName: 'Alice', text, timestamp: new Date() };
+}
+
+function makeDeps(
+  over: Partial<ChannelSummarizerDeps> = {},
+): ChannelSummarizerDeps {
+  return {
+    now: () => NOW,
+    intervalHours: 24,
+    jids: [JID],
+    getConnectedUsers: () => [
+      { sessionId: 's1', userId: 'u1', isConnected: true, encryptedAuthToken: 'enc' },
+    ],
+    decrypt: () => 'tok',
+    getLastSummarizedAt: vi.fn().mockResolvedValue(LAST),
+    setLastSummarizedAt: vi.fn().mockResolvedValue(undefined),
+    readWindowMessages: vi.fn().mockResolvedValue([msg('hi')]),
+    getGroupDisplayName: vi.fn().mockResolvedValue('Senior Staff Updates'),
+    summarize: vi.fn().mockResolvedValue('Alice shipped the release.'),
+    post: vi.fn().mockResolvedValue(undefined),
+    ...over,
+  };
+}
+
+describe('runChannelSummarizer', () => {
+  it('posts a correctly-shaped payload and advances the watermark on success', async () => {
+    const deps = makeDeps();
+    const stats = await runChannelSummarizer(deps);
+
+    expect(stats).toMatchObject({ posted: 1, skipped: 0, errors: 0 });
+    expect(deps.post).toHaveBeenCalledWith(
+      {
+        provider: 'whatsapp',
+        externalId: JID,
+        summary: 'Alice shipped the release.',
+        displayName: 'Senior Staff Updates',
+        windowStart: LAST.toISOString(),
+        windowEnd: NOW.toISOString(),
+        messageCount: 1,
+      },
+      { authToken: 'tok', userId: 'u1', sessionId: 's1' },
+    );
+    expect(deps.setLastSummarizedAt).toHaveBeenCalledWith('u1', JID, NOW);
+  });
+
+  it('skips zero-message windows without calling the model or posting', async () => {
+    const summarize = vi.fn();
+    const post = vi.fn();
+    const setLastSummarizedAt = vi.fn();
+    const deps = makeDeps({
+      readWindowMessages: vi.fn().mockResolvedValue([]),
+      summarize,
+      post,
+      setLastSummarizedAt,
+    });
+
+    const stats = await runChannelSummarizer(deps);
+
+    expect(stats).toMatchObject({ posted: 0, skipped: 1 });
+    expect(summarize).not.toHaveBeenCalled();
+    expect(post).not.toHaveBeenCalled();
+    expect(setLastSummarizedAt).not.toHaveBeenCalled();
+  });
+
+  it('suppresses an empty model result — no post, no watermark advance', async () => {
+    const post = vi.fn();
+    const setLastSummarizedAt = vi.fn();
+    const deps = makeDeps({
+      summarize: vi.fn().mockResolvedValue('   '),
+      post,
+      setLastSummarizedAt,
+    });
+
+    const stats = await runChannelSummarizer(deps);
+
+    expect(stats).toMatchObject({ posted: 0, skipped: 1 });
+    expect(post).not.toHaveBeenCalled();
+    expect(setLastSummarizedAt).not.toHaveBeenCalled();
+  });
+
+  it('does NOT advance the watermark when the POST fails (at-least-once)', async () => {
+    const setLastSummarizedAt = vi.fn();
+    const deps = makeDeps({
+      post: vi.fn().mockRejectedValue(new Error('502 from exponential')),
+      setLastSummarizedAt,
+    });
+
+    const stats = await runChannelSummarizer(deps);
+
+    expect(stats).toMatchObject({ posted: 0, errors: 1 });
+    expect(setLastSummarizedAt).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there are no watched groups', async () => {
+    const post = vi.fn();
+    const deps = makeDeps({ jids: [], post });
+
+    const stats = await runChannelSummarizer(deps);
+
+    expect(stats).toMatchObject({ groups: 0, posted: 0 });
+    expect(post).not.toHaveBeenCalled();
+  });
+});

--- a/src/mastra/proactive/channel-summarizer.ts
+++ b/src/mastra/proactive/channel-summarizer.ts
@@ -1,0 +1,345 @@
+/**
+ * Periodic channel summarizer (ADR-0023, exponential repo).
+ *
+ * A new gateway job, separate from the per-message Notion writer (untouched):
+ * once per cadence, for each watched WhatsApp group, summarize the traffic
+ * since the group's last summary and push ONE finished summary to exponential's
+ * `mastra.recordChannelSummary` endpoint. Raw messages never leave mastra.
+ *
+ * Design (ADR-0023):
+ *   - The cadence is a global env constant `WHATSAPP_SUMMARY_INTERVAL_HOURS`
+ *     (default 24); the *watching* authority remains `WHATSAPP_CAPTURE_GROUP_JIDS`.
+ *   - Window = "since `lastSummarizedAt`" (half-open). Zero messages → no LLM
+ *     call, no POST. An LLM "nothing project-relevant" result → no POST.
+ *   - The watermark advances ONLY after a 2xx, so a failed/dropped delivery
+ *     re-summarizes the same window next run (at-least-once; exponential dedups).
+ *
+ * The window math (`computeWindow`) and the post/skip decision (`shouldPost`)
+ * are pure functions; the LLM call and HTTP POST are thin shells around them.
+ * `runChannelSummarizer` takes its side-effecting collaborators as injectable
+ * dependencies so the orchestration is unit-testable without network/LLM/DB.
+ */
+import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+import { createLogger } from '../utils/logger.js';
+import { decryptToken } from '../utils/gateway-shared.js';
+import { authenticatedTrpcCall } from '../utils/authenticated-fetch.js';
+import {
+  getGroupDisplayName,
+  getLastSummarizedAt,
+  readWindowMessages,
+  setLastSummarizedAt,
+  type WindowMessage,
+} from '../bots/channel-summary-store.js';
+
+export type { WindowMessage } from '../bots/channel-summary-store.js';
+
+const logger = createLogger({ name: 'ChannelSummarizer', level: 'info' });
+
+const PROVIDER = 'whatsapp';
+const DEFAULT_INTERVAL_HOURS = 24;
+
+export interface SummaryWindow {
+  start: Date | null;
+  end: Date;
+}
+
+/**
+ * Half-open window `(start, end]` to summarize. `start` is the last watermark;
+ * on the first-ever run (no watermark) it bootstraps to one cadence interval
+ * before `now` so a fresh group doesn't summarize its entire history at once.
+ */
+export function computeWindow(
+  lastSummarizedAt: Date | null,
+  now: Date,
+  intervalHours = DEFAULT_INTERVAL_HOURS,
+): SummaryWindow {
+  if (lastSummarizedAt) {
+    return { start: lastSummarizedAt, end: now };
+  }
+  return {
+    start: new Date(now.getTime() - intervalHours * 60 * 60 * 1000),
+    end: now,
+  };
+}
+
+/**
+ * Whether a summary should be POSTed: only when the window had messages AND the
+ * model returned non-empty, project-relevant signal. Empty / whitespace-only
+ * results are the model's "nothing happened" signal and are suppressed.
+ */
+export function shouldPost(messageCount: number, llmResult: string): boolean {
+  return messageCount > 0 && llmResult.trim().length > 0;
+}
+
+/** Read the cadence (hours) from the env, falling back to the default. */
+export function summaryIntervalHours(): number {
+  const raw = Number(process.env.WHATSAPP_SUMMARY_INTERVAL_HOURS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_INTERVAL_HOURS;
+}
+
+/** Parse the watched-group allowlist (the *watching* authority). */
+export function watchedGroupJids(): string[] {
+  return (process.env.WHATSAPP_CAPTURE_GROUP_JIDS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+const SUMMARY_SYSTEM_PROMPT = [
+  'You summarize a window of group-chat messages into a short status update for a',
+  'workspace activity feed. Surface only project-relevant signal: decisions,',
+  'blockers, requests, commitments, deadlines, and notable updates. Name people by',
+  'their display name. Be concise — a few sentences at most, no preamble.',
+  '',
+  'CRITICAL: if nothing project-relevant happened (idle chatter, greetings,',
+  'off-topic banter, or nothing of substance), reply with an EMPTY string and',
+  'nothing else. Never invent activity. Never write "no significant activity" or',
+  'any filler — an empty reply means "skip".',
+].join(' ');
+
+/** Render captured messages into a compact transcript for the model. */
+function renderTranscript(messages: WindowMessage[]): string {
+  return messages
+    .map((m) => `${m.senderName ?? 'Unknown'}: ${m.text}`)
+    .join('\n');
+}
+
+/**
+ * LLM summarization (thin shell around the model). Returns trimmed text; an
+ * empty string means "nothing project-relevant — suppress".
+ */
+export async function summarizeMessages(
+  messages: WindowMessage[],
+): Promise<string> {
+  const { text } = await generateText({
+    model: openai('gpt-4o-mini'),
+    system: SUMMARY_SYSTEM_PROMPT,
+    prompt: renderTranscript(messages),
+  });
+  return text.trim();
+}
+
+export interface RecordChannelSummaryPayload {
+  provider: string;
+  externalId: string;
+  summary: string;
+  displayName?: string;
+  windowStart: string;
+  windowEnd: string;
+  messageCount: number;
+}
+
+/** Injectable collaborators — defaulted to the real implementations. */
+export interface ChannelSummarizerDeps {
+  now: () => Date;
+  intervalHours: number;
+  jids: string[];
+  getConnectedUsers: () => Array<{
+    sessionId: string;
+    userId: string;
+    isConnected: boolean;
+    encryptedAuthToken?: string;
+  }>;
+  decrypt: (encrypted: string) => string | null;
+  getLastSummarizedAt: (userId: string, jid: string) => Promise<Date | null>;
+  setLastSummarizedAt: (userId: string, jid: string, at: Date) => Promise<void>;
+  readWindowMessages: (
+    userId: string,
+    jid: string,
+    start: Date | null,
+    end: Date,
+  ) => Promise<WindowMessage[]>;
+  getGroupDisplayName: (userId: string, jid: string) => Promise<string | null>;
+  summarize: (messages: WindowMessage[]) => Promise<string>;
+  post: (
+    payload: RecordChannelSummaryPayload,
+    auth: { authToken: string; userId: string; sessionId: string },
+  ) => Promise<void>;
+}
+
+export interface ChannelSummarizerStats {
+  groups: number;
+  posted: number;
+  skipped: number;
+  errors: number;
+}
+
+async function defaultGetConnectedUsers() {
+  const { getWhatsAppGateway } = await import('../bots/whatsapp-gateway.js');
+  const gateway = getWhatsAppGateway();
+  return gateway ? gateway.getConnectedUsers() : [];
+}
+
+/** Default POST shell: throws on non-2xx (authenticatedTrpcCall throws). */
+async function defaultPost(
+  payload: RecordChannelSummaryPayload,
+  auth: { authToken: string; userId: string; sessionId: string },
+): Promise<void> {
+  await authenticatedTrpcCall('mastra.recordChannelSummary', payload, {
+    authToken: auth.authToken,
+    userId: auth.userId,
+    sessionId: auth.sessionId,
+    tokenKind: 'whatsapp-gateway',
+  });
+}
+
+function resolveDeps(
+  overrides?: Partial<ChannelSummarizerDeps>,
+): ChannelSummarizerDeps {
+  return {
+    now: () => new Date(),
+    intervalHours: summaryIntervalHours(),
+    jids: watchedGroupJids(),
+    // Real connected-users come from the gateway via defaultGetConnectedUsers()
+    // (resolved lazily in runChannelSummarizer to avoid a load-time circular
+    // import); this default is only the fallback when nothing is injected.
+    getConnectedUsers: () => [],
+    decrypt: (encrypted: string) =>
+      decryptToken(encrypted, process.env.AUTH_SECRET ?? ''),
+    getLastSummarizedAt,
+    setLastSummarizedAt,
+    readWindowMessages,
+    getGroupDisplayName,
+    summarize: summarizeMessages,
+    post: defaultPost,
+    ...overrides,
+  };
+}
+
+/**
+ * One summarization pass over every watched group, for every connected user
+ * whose session has captured it. Returns run stats. Never throws — per-group
+ * failures are logged and counted so one bad group can't abort the rest.
+ */
+export async function runChannelSummarizer(
+  overrides?: Partial<ChannelSummarizerDeps>,
+): Promise<ChannelSummarizerStats> {
+  const deps = resolveDeps(overrides);
+  const stats: ChannelSummarizerStats = {
+    groups: 0,
+    posted: 0,
+    skipped: 0,
+    errors: 0,
+  };
+
+  if (deps.jids.length === 0) {
+    logger.info('No watched groups (WHATSAPP_CAPTURE_GROUP_JIDS empty); nothing to summarize');
+    return stats;
+  }
+
+  const usersFromOverride = overrides?.getConnectedUsers;
+  const users = usersFromOverride
+    ? usersFromOverride()
+    : await defaultGetConnectedUsers();
+  const connected = users.filter((u) => u.isConnected && u.encryptedAuthToken);
+
+  if (connected.length === 0) {
+    logger.info('No connected users with auth tokens; nothing to summarize');
+    return stats;
+  }
+
+  for (const user of connected) {
+    const authToken = deps.decrypt(user.encryptedAuthToken!);
+    if (!authToken) {
+      logger.warn(`Failed to decrypt token for user ${user.userId}; skipping`);
+      continue;
+    }
+
+    for (const jid of deps.jids) {
+      stats.groups++;
+      try {
+        const now = deps.now();
+        const last = await deps.getLastSummarizedAt(user.userId, jid);
+        const window = computeWindow(last, now, deps.intervalHours);
+        const messages = await deps.readWindowMessages(
+          user.userId,
+          jid,
+          window.start,
+          window.end,
+        );
+
+        // Zero-message windows: no LLM call, no POST (and no watermark move).
+        if (messages.length === 0) {
+          stats.skipped++;
+          continue;
+        }
+
+        const summary = await deps.summarize(messages);
+        if (!shouldPost(messages.length, summary)) {
+          // Nothing project-relevant — suppress; leave the watermark so the
+          // window re-evaluates with later context next run.
+          stats.skipped++;
+          continue;
+        }
+
+        const displayName = await deps.getGroupDisplayName(user.userId, jid);
+        await deps.post(
+          {
+            provider: PROVIDER,
+            externalId: jid,
+            summary,
+            displayName: displayName ?? undefined,
+            windowStart: (window.start ?? window.end).toISOString(),
+            windowEnd: window.end.toISOString(),
+            messageCount: messages.length,
+          },
+          { authToken, userId: user.userId, sessionId: user.sessionId },
+        );
+
+        // Advance the watermark ONLY after a confirmed 2xx (post() resolved).
+        await deps.setLastSummarizedAt(user.userId, jid, window.end);
+        stats.posted++;
+      } catch (error) {
+        stats.errors++;
+        logger.error(
+          `Channel summary failed for user ${user.userId} group ${jid}:`,
+          error,
+        );
+      }
+    }
+  }
+
+  logger.info(
+    `Channel summarizer pass complete: ${stats.posted} posted, ` +
+      `${stats.skipped} skipped, ${stats.errors} error(s) over ${stats.groups} group-checks`,
+  );
+  return stats;
+}
+
+let timer: NodeJS.Timeout | null = null;
+
+/**
+ * Register the periodic summarizer on the cadence env (default 24h). Opt-in via
+ * `ENABLE_CHANNEL_SUMMARIZER=true` so it never fires against prod data during a
+ * local `mastra dev` boot. Safe to call once at gateway startup.
+ */
+export function startChannelSummarizer(): void {
+  if (process.env.ENABLE_CHANNEL_SUMMARIZER !== 'true') {
+    logger.info(
+      'Channel summarizer disabled (set ENABLE_CHANNEL_SUMMARIZER=true to enable)',
+    );
+    return;
+  }
+  if (timer) return;
+
+  const intervalMs = summaryIntervalHours() * 60 * 60 * 1000;
+  timer = setInterval(() => {
+    runChannelSummarizer().catch((err) => {
+      logger.error('Channel summarizer run failed:', err);
+    });
+  }, intervalMs);
+  // Don't keep the event loop alive solely for this timer.
+  timer.unref?.();
+  logger.info(
+    `Channel summarizer started (every ${summaryIntervalHours()}h)`,
+  );
+}
+
+export function stopChannelSummarizer(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}

--- a/src/mastra/proactive/index.ts
+++ b/src/mastra/proactive/index.ts
@@ -8,6 +8,11 @@ export { checkUser } from './checker.js';
 export { initNotifier, notifyUser, formatDailyDigest } from './notifier.js';
 export { startScheduler, stopScheduler, triggerCheck } from './scheduler.js';
 export { formatBriefingForWhatsApp, deliverWhatsAppBriefings } from './whatsapp-briefing.js';
+export {
+  startChannelSummarizer,
+  stopChannelSummarizer,
+  runChannelSummarizer,
+} from './channel-summarizer.js';
 export type {
   ProactiveCheckResult,
   UserContext,


### PR DESCRIPTION
## What

The mastra-side slice of the channel-summaries feature (ADR-0023 lives in the exponential repo). A new periodic summarizer job in the WhatsApp gateway, **separate from the per-message Notion writer (untouched)**.

Once per `WHATSAPP_SUMMARY_INTERVAL_HOURS` (default 24), for each watched group (`WHATSAPP_CAPTURE_GROUP_JIDS` remains the *watching* authority):
1. Read messages since the group's `lastSummarizedAt` (half-open window).
2. **Zero messages → no LLM call, no POST.**
3. LLM-summarize with an **empty-suppression** instruction; an empty/"nothing project-relevant" result → **no POST**.
4. Otherwise POST `{ provider: "whatsapp", externalId: <jid>, summary, displayName, windowStart, windowEnd, messageCount }` to exponential's `mastra.recordChannelSummary` (agent JWT, via the connected user's token).
5. **Advance the watermark only on a 2xx** — a failed/dropped delivery re-summarizes the same window next run (at-least-once; exponential dedups by `(provider, externalId, windowStart)`).

Raw messages **never leave mastra** — only the finished summary is pushed.

### Design
- **Pure core**: `computeWindow(lastSummarizedAt, now)` and `shouldPost(messageCount, llmResult)`. The LLM call and HTTP POST are thin shells; `runChannelSummarizer` takes its side-effecting collaborators as injectable deps for testing.
- **Store**: new `whatsapp_messages.channel_watermarks` table (per user+group `last_summarized_at`), created lazily (mastra has no migrations) alongside read-only window queries against the existing captured-messages table.
- **Opt-in**: registered at gateway startup but gated by `ENABLE_CHANNEL_SUMMARIZER=true`, so it never fires against prod data during a local `mastra dev` boot.

## Acceptance criteria

- [x] New scheduled job on the cadence env (default 24h), independent of the Notion writer.
- [x] Window is "since `lastSummarizedAt`"; watermark advances only after a 2xx.
- [x] Zero-message windows make no LLM call and no POST.
- [x] An LLM "nothing project-relevant" result makes no POST.
- [x] A non-empty summary POSTs the correct payload to `recordChannelSummary`.
- [x] `computeWindow` and `shouldPost` are pure and unit-tested (false on 0 messages and empty result, true otherwise) — no network/LLM/DB.
- [x] Env wiring documented (`WHATSAPP_SUMMARY_INTERVAL_HOURS`, `ENABLE_CHANNEL_SUMMARIZER`, `WHATSAPP_CAPTURE_GROUP_JIDS`, `TODO_APP_BASE_URL`, `AUTH_SECRET`) in CLAUDE.md.

## Tests

`src/mastra/proactive/channel-summarizer.test.ts` — 11 tests: `computeWindow`, `shouldPost`, and the orchestrator (happy-path payload + watermark advance, zero-message skip, empty-suppression, POST-failure leaves watermark, no-watched-groups). Full mastra suite: 108 passing. `tsc --noEmit` clean for the new files.

> Go-live (connect the HSS group, set env, deploy via `railway up`) is the separate exponential ticket coral.mist (HITL).

Refs: upper.duck