### PR TITLE
fix(crm): forward active workspace from Zoe contact-create tools

### DIFF
--- a/src/mastra/tools/index.ts
+++ b/src/mastra/tools/index.ts
@@ -2002,6 +2002,9 @@ export const createCrmContactTool = createTool({
     const authToken = requestContext?.get("authToken");
     const sessionId = requestContext?.get("whatsappSession");
     const userId = requestContext?.get("userId");
+    // Forward the active chat workspace so the contact lands in it, not an
+    // arbitrary one the server falls back to (see exponential thick.ocean).
+    const workspaceId = requestContext?.get("workspaceId");
 
     if (!authToken) {
       console.error("❌ [createCrmContact] No authentication token available");
@@ -2016,7 +2019,7 @@ export const createCrmContactTool = createTool({
         error?: string;
       }>(
         "mastra.createCrmContact",
-        { email, phone, firstName, lastName },
+        { email, phone, firstName, lastName, ...(workspaceId ? { workspaceId } : {}) },
         { authToken, sessionId, userId }
       );
 
@@ -2197,6 +2200,9 @@ export const createFullCrmContactTool = createTool({
     const authToken = requestContext?.get("authToken");
     const sessionId = requestContext?.get("whatsappSession");
     const userId = requestContext?.get("userId");
+    // Forward the active chat workspace so the contact lands in it, not an
+    // arbitrary one the server falls back to (see exponential thick.ocean).
+    const workspaceId = requestContext?.get("workspaceId");
 
     console.log(`➕ [createFullCrmContact] Creating: ${inputData.firstName} ${inputData.lastName}`);
 
@@ -2211,7 +2217,7 @@ export const createFullCrmContactTool = createTool({
       email: string | null;
     }>(
       "mastra.createFullCrmContact",
-      inputData,
+      { ...inputData, ...(workspaceId ? { workspaceId } : {}) },
       { authToken, sessionId, userId }
     );
 


### PR DESCRIPTION
## Ticket

Fixes **eager.moth** (#194) — _Zoe CRM contact tools forward the active workspace_.

Second of two coordinated BUG fixes for agent-created CRM contacts landing in the wrong workspace. The endpoint half — exponential **thick.ocean** (#193), [exponential PR #265](https://github.com/positonic/exponential/pull/265) — is **already merged to `main`**, so the endpoints now accept and validate an optional `workspaceId`.

## Problem

`createFullCrmContactTool` and `createCrmContactTool` read `authToken` / `whatsappSession` / `userId` from the agent `requestContext` but never `workspaceId`, so the active chat workspace was dropped on the write path. The server then fell back to an arbitrary workspace (`findFirst`, no `orderBy`) and the contact landed in the wrong place.

## Change

Both tools now read `const workspaceId = requestContext?.get("workspaceId")` — exactly mirroring `getAllProjectsTool` (`index.ts:977`) — and forward it in the `authenticatedTrpcCall` payload to `mastra.createFullCrmContact` / `mastra.createCrmContact`.

`workspaceId` is sourced from `requestContext`, not the tool's `inputSchema`, so the LLM can't set (or hallucinate) it. When no workspace is in context the field is omitted and the endpoint's existing fallback applies — no behavior change for callers/paths without an active workspace.

## Verification

- `npx tsc --noEmit`: my change adds **zero** new type errors. The 4 errors that remain are pre-existing in `calendar-tools.test.ts` on `main` (a `.parse`-on-schema issue) and are byte-identical with/without this change. (The exponential ESLint PostToolUse hook false-positives cross-repo — verified with `tsc` per the ticket, not that hook.)
- End-to-end: with #265 merged, creating a contact from a chat scoped to a non-personal workspace (e.g. Syntrofi) now routes `workspaceId` through `requestContext → tool payload → endpoint → getWorkspaceMembership` and lands the contact in that workspace.